### PR TITLE
added more modularization + versions for tracking for FST, BARREL & LBL

### DIFF
--- a/common/G4_AllSilicon.C
+++ b/common/G4_AllSilicon.C
@@ -26,7 +26,7 @@ void AllSiliconSetup(PHG4Reco *g4Reco)
   allsili->AddAssemblyVolume("VST");       // Barrel
   allsili->AddAssemblyVolume("FST");       // Forward disks
   allsili->AddAssemblyVolume("BST");       // Backward disks
-  allsili->AddAssemblyVolume("BEAMPIPE");  // Beampipe
+  //allsili->AddAssemblyVolume("BEAMPIPE");  // Beampipe
   allsili->SuperDetector("LBLVTX");
   allsili->OverlapCheck(OverlapCheck);
   allsili->SetActive();                              // this saves hits in the MimosaCore volumes

--- a/common/G4_TTL_EIC.C
+++ b/common/G4_TTL_EIC.C
@@ -170,12 +170,12 @@ int make_barrel_layer(string name, PHG4Reco *g4Reco,
 
   double max_bh_radius = 0.;
   PHG4CylinderSubsystem* cyl;
-  cout << "started to create cylinder layer: " << name << endl;
+//   cout << "started to create cylinder layer: " << name << endl;
   
   double currRadius = radius;
-  cout << currRadius << endl;
+//   cout << currRadius << endl;
   for (int l = 0; l < nSubLayer; l++) {
-    cout << name <<"_"<< layerName[l] << endl;
+//     cout << name <<"_"<< layerName[l] << endl;
     cyl = new PHG4CylinderSubsystem(name + "_" + layerName[l],l);
     cyl->SuperDetector(name);
     cyl->set_double_param("radius", currRadius);
@@ -186,7 +186,7 @@ int make_barrel_layer(string name, PHG4Reco *g4Reco,
     cyl->OverlapCheck(true);
     g4Reco->registerSubsystem(cyl);
     currRadius = currRadius+thickness[l];
-    cout << currRadius << endl;
+//     cout << currRadius << endl;
   }
 
   return 0;

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -32,7 +32,7 @@ int Fun4All_G4_FullDetectorModular(
     const int nEvents = 1,
     const double particlemomMin = -1,
     const double particlemomMax = -1,
-    TString specialSetting = "",
+    TString specialSetting = "ALLSILICON-FTTLS3LC-ETTL-CTTL-pTHard5",
     TString pythia6Settings = "",
     const string &inputFile = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
     const string &outputFile = "G4EICDetector.root",

--- a/detectors/Modular/G4Setup_EICDetector.C
+++ b/detectors/Modular/G4Setup_EICDetector.C
@@ -157,9 +157,9 @@ int G4Setup(TString specialSetting = "")
   // trackers
   if (Enable::EGEM) EGEMSetup(g4Reco);
   if (Enable::FGEM) FGEMSetup(g4Reco);
-  if (Enable::FST) FSTSetup(g4Reco);
+  if (Enable::FST) FSTSetup(g4Reco, 1.2, specialSetting);
   if (Enable::ALLSILICON) AllSiliconSetup(g4Reco);
-  if (Enable::BARREL) Barrel(g4Reco, radius);
+  if (Enable::BARREL) Barrel(g4Reco, radius, specialSetting);
   if (Enable::MVTX) radius = Mvtx(g4Reco, radius);
   if (Enable::TPC) radius = TPC(g4Reco, radius);
   if (Enable::FTTL) FTTLSetup(g4Reco,specialSetting);


### PR DESCRIPTION
- FST and Barrel setups now configurable according to (2009.0288)
- pitch corrected for LBL tracker 10->20mu m
- beam pipe removed from LBL tracker geom setup
-  Allow to store hits on all silicon tracker/ timing plane per track