### PR TITLE
Adjust modular

### DIFF
--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -4,7 +4,7 @@
 #include <GlobalVariables.C>
 
 #include <DisplayOn.C>
-#include <G4Setup_EICDetector.C>
+#include <G4Setup_ModularDetector.C>
 #include <G4_Bbc.C>
 #include <G4_CaloTrigger.C>
 #include <G4_DSTReader_EICDetector.C>
@@ -28,6 +28,8 @@
 
 R__LOAD_LIBRARY(libfun4all.so)
 
+void ParseTString(TString &specialSetting);
+
 int Fun4All_G4_FullDetectorModular(
     const int nEvents = 1,
     const double particlemomMin = -1,
@@ -40,6 +42,8 @@ int Fun4All_G4_FullDetectorModular(
     const int skip = 0,
     const string &outdir = ".")
 {
+// translate the option TString into subsystem namespace options
+  ParseTString(specialSetting); 
   //---------------
   // Fun4All server
   //---------------
@@ -54,7 +58,7 @@ int Fun4All_G4_FullDetectorModular(
   // PHRandomSeed() which reads /dev/urandom to get its seed
   // if the RANDOMSEED flag is set its value is taken as initial seed
   // which will produce identical results so you can debug your code
-  // rc->set_IntFlag("RANDOMSEED", 12345);
+  rc->set_IntFlag("RANDOMSEED", 12345);
 
   //===============
   // Input options
@@ -159,7 +163,7 @@ int Fun4All_G4_FullDetectorModular(
   // Write the DST
   //======================
 
-  //  Enable::DSTOUT = true;
+  Enable::DSTOUT = true;
   DstOut::OutputDir = outdir;
   DstOut::OutputFile = outputFile;
   Enable::DSTOUT_COMPRESS = false;  // Compress DST files
@@ -278,6 +282,7 @@ int Fun4All_G4_FullDetectorModular(
   Enable::FEMC_EVAL = Enable::FEMC_CLUSTER && true;
 
   Enable::FHCAL = true;
+
   Enable::FHCAL_VERBOSITY = 1;
   //  Enable::FHCAL_ABSORBER = true;
   Enable::FHCAL_CELL = Enable::FHCAL && true;
@@ -361,8 +366,6 @@ int Fun4All_G4_FullDetectorModular(
   if (Enable::CEMC_CELL) CEMC_Cells();
   if (Enable::HCALIN_CELL) HCALInner_Cells();
   if (Enable::HCALOUT_CELL) HCALOuter_Cells();
-  if (Enable::FEMC_CELL) FEMC_Cells();
-  if (Enable::FHCAL_CELL) FHCAL_Cells();
   if (Enable::EEMC_CELL) EEMC_Cells();
 
   //-----------------------------
@@ -383,10 +386,10 @@ int Fun4All_G4_FullDetectorModular(
   //-----------------------------
   // e, h direction Calorimeter  towering and clustering
   //-----------------------------
-  if (Enable::FEMC_TOWER) FEMC_Towers(specialSetting);
+  if (Enable::FEMC_TOWER) FEMC_Towers();
   if (Enable::FEMC_CLUSTER) FEMC_Clusters();
 
-  if (Enable::FHCAL_TOWER) FHCAL_Towers(specialSetting);
+  if (Enable::FHCAL_TOWER) FHCAL_Towers();
   if (Enable::FHCAL_CLUSTER) FHCAL_Clusters();
 
   if (Enable::EEMC_TOWER) EEMC_Towers();
@@ -508,4 +511,60 @@ int Fun4All_G4_FullDetectorModular(
   gSystem->Exit(0);
   return 0;
 }
+
+void ParseTString(TString &specialSetting)
+{
+  if (specialSetting.Contains("BARRELV1"))
+  {
+    G4BARREL::SETTING::BARRELV1 = true;
+  }
+  else if (specialSetting.Contains("BARRELV2"))
+  {
+    G4BARREL::SETTING::BARRELV2 = true;
+  }
+  else if (specialSetting.Contains("BARRELV3"))
+  {
+    G4BARREL::SETTING::BARRELV3 = true;
+  }
+  else if (specialSetting.Contains("BARRELV4"))
+  {
+    G4BARREL::SETTING::BARRELV4 = true;
+  }
+  if (specialSetting.Contains("fsPHENIX"))
+  {
+    G4FEMC::SETTING::fsPHENIX = true;
+  }
+
+  if (specialSetting.Contains("FullEtaAcc"))
+  {
+    G4FHCAL::SETTING::FullEtaAcc = true;
+    G4FEMC::SETTING::FullEtaAcc = true;
+  }
+  else if (specialSetting.Contains("HC2x"))
+  {
+    G4FHCAL::SETTING::HC2x = true;
+  }
+  else if (specialSetting.Contains("HC4x"))
+  {
+    G4FHCAL::SETTING::HC4x = true;
+  }
+
+  if (specialSetting.Contains("towercalib1"))
+  {
+    G4FHCAL::SETTING::towercalib1 = true;
+  }
+  else if (specialSetting.Contains("towercalibSiPM"))
+  {
+    G4FHCAL::SETTING::towercalibSiPM = true;
+  }
+  else if (specialSetting.Contains("towercalibHCALIN"))
+  {
+    G4FHCAL::SETTING::towercalibHCALIN = true;
+  }
+  else if (specialSetting.Contains("towercalib3"))
+  {
+    G4FHCAL::SETTING::towercalib3 = true;
+  }
+}
+
 #endif

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -514,6 +514,7 @@ int Fun4All_G4_FullDetectorModular(
 
 void ParseTString(TString &specialSetting)
 {
+// Barrel settings
   if (specialSetting.Contains("BARRELV1"))
   {
     G4BARREL::SETTING::BARRELV1 = true;
@@ -531,6 +532,7 @@ void ParseTString(TString &specialSetting)
     G4BARREL::SETTING::BARRELV4 = true;
   }
 
+// FST settings
   if (specialSetting.Contains("FSTV1"))
   {
     G4FST::SETTING::FSTV1 = true;
@@ -556,12 +558,14 @@ void ParseTString(TString &specialSetting)
     G4FST::SETTING::FSTV42 = true;
   }
 
+
+// FHCAL/FEMC settings
   if (specialSetting.Contains("fsPHENIX"))
   {
     G4FEMC::SETTING::fsPHENIX = true;
   }
 
-  if (specialSetting.Contains("FullEtaAcc"))
+  if (specialSetting.Contains("FullEtaAcc")) // common for FHCAL and FEMC
   {
     G4FHCAL::SETTING::FullEtaAcc = true;
     G4FEMC::SETTING::FullEtaAcc = true;

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -530,6 +530,32 @@ void ParseTString(TString &specialSetting)
   {
     G4BARREL::SETTING::BARRELV4 = true;
   }
+
+  if (specialSetting.Contains("FSTV1"))
+  {
+    G4FST::SETTING::FSTV1 = true;
+  }
+  else if (specialSetting.Contains("FSTV2"))
+  {
+    G4FST::SETTING::FSTV2 = true;
+  }
+  else if (specialSetting.Contains("FSTV3"))
+  {
+    G4FST::SETTING::FSTV3 = true;
+  }
+  else if (specialSetting.Contains("FSTV4"))
+  {
+    G4FST::SETTING::FSTV4 = true;
+  }
+  else if (specialSetting.Contains("FSTV41"))
+  {
+    G4FST::SETTING::FSTV41 = true;
+  }
+  else if (specialSetting.Contains("FSTV42"))
+  {
+    G4FST::SETTING::FSTV42 = true;
+  }
+
   if (specialSetting.Contains("fsPHENIX"))
   {
     G4FEMC::SETTING::fsPHENIX = true;

--- a/detectors/Modular/G4Setup_ModularDetector.C
+++ b/detectors/Modular/G4Setup_ModularDetector.C
@@ -157,7 +157,7 @@ int G4Setup(TString specialSetting = "")
   // trackers
   if (Enable::EGEM) EGEMSetup(g4Reco);
   if (Enable::FGEM) FGEMSetup(g4Reco);
-  if (Enable::FST) FSTSetup(g4Reco, 1.2, specialSetting);
+  if (Enable::FST) FSTSetup(g4Reco, 1.2);
   if (Enable::ALLSILICON) AllSiliconSetup(g4Reco);
   if (Enable::BARREL) Barrel(g4Reco, radius);
   if (Enable::MVTX) radius = Mvtx(g4Reco, radius);

--- a/detectors/Modular/G4Setup_ModularDetector.C
+++ b/detectors/Modular/G4Setup_ModularDetector.C
@@ -1,0 +1,299 @@
+#ifndef MACRO_G4SETUPMODULARDETECTOR_C
+#define MACRO_G4SETUPMODULARDETECTOR_C
+
+#include <GlobalVariables.C>
+
+#include <G4_Aerogel.C>
+#include <G4_Barrel_EIC.C>
+#include <G4_AllSilicon.C>
+#include <G4_FST_EIC.C>
+#include <G4_TTL_EIC.C>
+#include <G4_GEM_EIC.C>
+#include <G4_Bbc.C>
+#include <G4_BlackHole.C>
+#include <G4_CEmc_EIC.C>
+#include <G4_DIRC.C>
+#include <G4_EEMC.C>
+#include <G4_FEMC_EIC.C>
+#include <G4_FHCAL.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Input.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx_EIC.C>
+#include <G4_Pipe_EIC.C>
+#include <G4_PlugDoor_EIC.C>
+#include <G4_RICH.C>
+#include <G4_TPC_EIC.C>
+#include <G4_Tracking_Modular.C>
+#include <G4_User.C>
+#include <G4_World.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4eval/PHG4DstCompressReco.h>
+
+#include <g4main/PHG4Reco.h>
+#include <g4main/PHG4TruthSubsystem.h>
+
+#include <phfield/PHFieldConfig.h>
+
+#include <g4decayer/EDecayType.hh>
+
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libg4decayer.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+
+void G4Init()
+{
+  // First some check for subsystems which do not go together
+
+  if (Enable::TPC && Enable::FST){
+    cout << "TPC and FST cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  } else if ((Enable::TPC || Enable::MVTX) && Enable::BARREL){
+    cout << "TPC/MVTX and BARREL cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  } else if ( (Enable::FST && Enable::ALLSILICON) || 
+              (Enable::BARREL && Enable::ALLSILICON) ){
+    cout << "FST and ALLSILICON or BARREL and ALLSILICON cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  } else if ( (Enable::EGEM && Enable::ALLSILICON && Enable::EGEM_FULL) ){
+              
+    cout << "EGEM and ALLSILICON cannot be enabled together, if EGEM is using full setup, set Enable::EGEM_FULL to false to run in parallel" << endl;
+    gSystem->Exit(1);
+  } else if ( (Enable::FGEM && Enable::ALLSILICON) ) {
+    cout << "FGEM and ALLSILICON cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  } else if ( (Enable::FGEM && Enable::FTTL) ) {
+    cout << "FGEM and FTTL cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  }
+
+  // load detector/material macros and execute Init() function
+  if (Enable::PLUGDOOR) PlugDoorInit();
+  if (Enable::MAGNET) MagnetInit();
+  MagnetFieldInit(); // We want the field - even if the magnet volume is disabled
+  if (Enable::PIPE) PipeInit();
+  // trackers
+  if (Enable::EGEM) EGEM_Init();
+  if (Enable::FGEM) FGEM_Init();
+  if (Enable::FST) FST_Init();
+  if (Enable::ALLSILICON) AllSiliconInit();
+  if (Enable::FTTL || Enable::ETTL  || Enable::CTTL) TTL_Init();
+  if (Enable::BARREL) BarrelInit();
+  if (Enable::MVTX) MvtxInit();
+  if (Enable::TPC) TPCInit();
+  // PID
+  if (Enable::DIRC) DIRCInit();
+  if (Enable::RICH) RICHInit();
+  if (Enable::AEROGEL) AerogelInit();
+  
+  // calorimeters
+  if (Enable::CEMC) CEmcInit(72);  // make it 2*2*2*3*3 so we can try other combinations
+  if (Enable::HCALIN) HCalInnerInit(1);
+  if (Enable::HCALOUT) HCalOuterInit();
+  if (Enable::FEMC) FEMCInit();
+  if (Enable::FHCAL) FHCALInit();
+  if (Enable::EEMC) EEMCInit();
+  
+  // very forward detectors
+  if (Enable::BBC) BbcInit();
+  
+  // tracking
+  if (Enable::TRACKING) TrackingInit();
+
+  // others
+  if (Enable::USER) UserInit();
+  if (Enable::BLACKHOLE) BlackHoleInit();
+  
+  
+}
+
+int G4Setup(TString specialSetting = "")
+{
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4Reco *g4Reco = new PHG4Reco();
+
+  WorldInit(g4Reco);
+
+  g4Reco->set_rapidity_coverage(1.1);  // according to drawings
+                                       // uncomment to set QGSP_BERT_HP physics list for productions
+                                       // (default is QGSP_BERT for speed)
+  //  g4Reco->SetPhysicsList("QGSP_BERT_HP");
+
+  if (G4P6DECAYER::decayType != EDecayType::kAll){
+    g4Reco->set_force_decay(G4P6DECAYER::decayType);
+  }
+
+  double fieldstrength;
+  istringstream stringline(G4MAGNET::magfield);
+  stringline >> fieldstrength;
+  if (stringline.fail())
+  {  // conversion to double fails -> we have a string
+
+    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos){
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
+    } else {
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::kField2D);
+    }
+  } else {
+    g4Reco->set_field(fieldstrength);  // use const soleniodal field
+  }
+  g4Reco->set_field_rescale(G4MAGNET::magfield_rescale);
+
+// the radius is an older protection against overlaps, it is not
+// clear how well this works nowadays but it doesn't hurt either
+  double radius = 0.;
+  if (Enable::PIPE) radius = Pipe(g4Reco, radius);
+  //----------------------------------------
+  // trackers
+  if (Enable::EGEM) EGEMSetup(g4Reco);
+  if (Enable::FGEM) FGEMSetup(g4Reco);
+  if (Enable::FST) FSTSetup(g4Reco, 1.2, specialSetting);
+  if (Enable::ALLSILICON) AllSiliconSetup(g4Reco);
+  if (Enable::BARREL) Barrel(g4Reco, radius);
+  if (Enable::MVTX) radius = Mvtx(g4Reco, radius);
+  if (Enable::TPC) radius = TPC(g4Reco, radius);
+  if (Enable::FTTL) FTTLSetup(g4Reco,specialSetting);
+  if (Enable::ETTL) ETTLSetup(g4Reco,specialSetting);
+  if (Enable::CTTL) CTTLSetup(g4Reco,specialSetting);
+  
+  //----------------------------------------
+  // beam counters
+  if (Enable::BBC) Bbc(g4Reco);
+  //----------------------------------------
+  // calos
+  if (Enable::CEMC) radius = CEmc(g4Reco, radius);
+  if (Enable::HCALIN) radius = HCalInner(g4Reco, radius, 4);
+  if (Enable::MAGNET) radius = Magnet(g4Reco, radius);
+  if (Enable::HCALOUT) radius = HCalOuter(g4Reco, radius, 4);
+  if (Enable::FEMC) FEMCSetup(g4Reco);
+  if (Enable::FHCAL) FHCALSetup(g4Reco);
+  if (Enable::EEMC) EEMCSetup(g4Reco);
+
+  //----------------------------------------
+  // PID
+  if (Enable::DIRC) DIRCSetup(g4Reco);
+  if (Enable::RICH) RICHSetup(g4Reco);
+  if (Enable::AEROGEL) AerogelSetup(g4Reco);
+
+  //----------------------------------------
+  // sPHENIX forward flux return door
+  if (Enable::PLUGDOOR) PlugDoor(g4Reco);
+  if (Enable::USER) UserDetector(g4Reco);
+  
+  //----------------------------------------
+  // BLACKHOLE if enabled, needs info from all previous sub detectors for dimensions
+  if (Enable::BLACKHOLE) BlackHole(g4Reco, radius);
+
+  PHG4TruthSubsystem *truth = new PHG4TruthSubsystem();
+  g4Reco->registerSubsystem(truth);
+  // finally adjust the world size in case the default is too small
+  WorldSize(g4Reco, radius);
+
+  se->registerSubsystem(g4Reco);
+  return 0;
+}
+
+void ShowerCompress()
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4DstCompressReco *compress = new PHG4DstCompressReco("PHG4DstCompressReco");
+  compress->AddHitContainer("G4HIT_PIPE");
+  compress->AddHitContainer("G4HIT_FIELDCAGE");
+  compress->AddHitContainer("G4HIT_CEMC_ELECTRONICS");
+  compress->AddHitContainer("G4HIT_CEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_CEMC");
+  compress->AddHitContainer("G4HIT_CEMC_SPT");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN_SPT");
+  compress->AddHitContainer("G4HIT_MAGNET");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALOUT");
+  compress->AddHitContainer("G4HIT_HCALOUT");
+  compress->AddHitContainer("G4HIT_BH_1");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_PLUS");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_NEG");
+  compress->AddCellContainer("G4CELL_CEMC");
+  compress->AddCellContainer("G4CELL_HCALIN");
+  compress->AddCellContainer("G4CELL_HCALOUT");
+  compress->AddTowerContainer("TOWER_SIM_CEMC");
+  compress->AddTowerContainer("TOWER_RAW_CEMC");
+  compress->AddTowerContainer("TOWER_CALIB_CEMC");
+  compress->AddTowerContainer("TOWER_SIM_HCALIN");
+  compress->AddTowerContainer("TOWER_RAW_HCALIN");
+  compress->AddTowerContainer("TOWER_CALIB_HCALIN");
+  compress->AddTowerContainer("TOWER_SIM_HCALOUT");
+  compress->AddTowerContainer("TOWER_RAW_HCALOUT");
+  compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+
+  compress->AddHitContainer("G4HIT_FEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_FEMC");
+  compress->AddHitContainer("G4HIT_FHCAL");
+  compress->AddHitContainer("G4HIT_ABSORBER_FHCAL");
+  compress->AddCellContainer("G4CELL_FEMC");
+  compress->AddCellContainer("G4CELL_FHCAL");
+  compress->AddTowerContainer("TOWER_SIM_FEMC");
+  compress->AddTowerContainer("TOWER_RAW_FEMC");
+  compress->AddTowerContainer("TOWER_CALIB_FEMC");
+  compress->AddTowerContainer("TOWER_SIM_FHCAL");
+  compress->AddTowerContainer("TOWER_RAW_FHCAL");
+  compress->AddTowerContainer("TOWER_CALIB_FHCAL");
+
+  compress->AddHitContainer("G4HIT_EEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_EEMC");
+  compress->AddCellContainer("G4CELL_EEMC");
+  compress->AddTowerContainer("TOWER_SIM_EEMC");
+  compress->AddTowerContainer("TOWER_RAW_EEMC");
+  compress->AddTowerContainer("TOWER_CALIB_EEMC");
+
+  se->registerSubsystem(compress);
+
+  return;
+}
+
+void DstCompress(Fun4AllDstOutputManager *out)
+{
+  if (out)
+  {
+    out->StripNode("G4HIT_PIPE");
+    out->StripNode("G4HIT_SVTXSUPPORT");
+    out->StripNode("G4HIT_CEMC_ELECTRONICS");
+    out->StripNode("G4HIT_CEMC");
+    out->StripNode("G4HIT_ABSORBER_CEMC");
+    out->StripNode("G4HIT_CEMC_SPT");
+    out->StripNode("G4HIT_ABSORBER_HCALIN");
+    out->StripNode("G4HIT_HCALIN");
+    out->StripNode("G4HIT_HCALIN_SPT");
+    out->StripNode("G4HIT_MAGNET");
+    out->StripNode("G4HIT_ABSORBER_HCALOUT");
+    out->StripNode("G4HIT_HCALOUT");
+    out->StripNode("G4HIT_BH_1");
+    out->StripNode("G4HIT_BH_FORWARD_PLUS");
+    out->StripNode("G4HIT_BH_FORWARD_NEG");
+    out->StripNode("G4CELL_CEMC");
+    out->StripNode("G4CELL_HCALIN");
+    out->StripNode("G4CELL_HCALOUT");
+
+    out->StripNode("G4HIT_FEMC");
+    out->StripNode("G4HIT_ABSORBER_FEMC");
+    out->StripNode("G4HIT_FHCAL");
+    out->StripNode("G4HIT_ABSORBER_FHCAL");
+    out->StripNode("G4CELL_FEMC");
+    out->StripNode("G4CELL_FHCAL");
+
+    out->StripNode("G4HIT_EEMC");
+    out->StripNode("G4HIT_ABSORBER_EEMC");
+    out->StripNode("G4CELL_EEMC");
+  }
+}
+#endif


### PR DESCRIPTION
This PR removes the TStrings from the macros which are common with sPHENIX. Using strings for options can lead to hard to find ambiguities (one option accidentally being a substring of an unrelated other option). One also cannot set parameters via strings (okay one can do that but then the parsing gets to be real fun)