### PR TITLE
Move of EIC related macro's from sPHENIX to eic userspace

### DIFF
--- a/common/G4_Aerogel.C
+++ b/common/G4_Aerogel.C
@@ -1,0 +1,57 @@
+#ifndef MACRO_G4AEROGEL_C
+#define MACRO_G4AEROGEL_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4SectorSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+/*!
+ * \file G4_Aerogel.C
+ * \brief Aerogel RICH for EIC detector
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.2 $
+ * \date $Date: 2013/10/09 01:08:17 $
+ */
+
+namespace Enable
+{
+  bool AEROGEL = false;
+  bool AEROGEL_OVERLAPCHECK = false;
+}  // namespace Enable
+
+void AerogelInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 164.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 287.);
+}
+
+void AerogelSetup(PHG4Reco* g4Reco, const int N_Sector = 8,  //
+                  const double min_eta = 1.242)
+{
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::AEROGEL_OVERLAPCHECK;
+
+  PHG4SectorSubsystem* ag = new PHG4SectorSubsystem("Aerogel");
+
+  ag->get_geometry().set_normal_polar_angle((PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) +
+                                             PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) /
+                                            2);
+  //  ag->get_geometry().set_normal_polar_angle(0);
+  ag->get_geometry().set_normal_start(280 * PHG4Sector::Sector_Geometry::Unit_cm());  // 307
+  ag->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(1.85));
+  ag->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+  ag->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  ag->get_geometry().set_material("G4_AIR");
+  ag->get_geometry().set_N_Sector(N_Sector);
+  ag->OverlapCheck(OverlapCheck);
+
+  // Aerogel dimensions ins cm
+  double radiator_length = 2.;
+  double expansion_length = 18.;  // 10.;
+
+  ag->get_geometry().AddLayers_AeroGel_ePHENIX(radiator_length * PHG4Sector::Sector_Geometry::Unit_cm(),
+                                               expansion_length * PHG4Sector::Sector_Geometry::Unit_cm());
+  g4Reco->registerSubsystem(ag);
+}
+#endif

--- a/common/G4_Barrel_EIC.C
+++ b/common/G4_Barrel_EIC.C
@@ -1,0 +1,207 @@
+/*---------------------------------------------------------------------*
+ * Barrel tracker designed by LANL EIC team                            *
+ * See technical notes for details: arXiv:2009.02888                   *
+ * Contact Ping and Xuan @LANL for questions:                          *
+ *   Xuan: xuanli@lanl.gov                                             *
+ *   Ping: cpwong@lanl.gov                                             *
+ *---------------------------------------------------------------------*/
+
+#ifndef MACRO_G4BARRELEIC_C
+#define MACRO_G4BARRELEIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+#include <cmath>
+#include <vector>
+
+R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libg4mvtx.so)
+
+int make_barrel_pixel_layer(const string &name, PHG4Reco *g4Reco,
+                            double radius, double halflength, double tSilicon, double tAirgap);
+
+//---------------------------------------------------------------------//
+namespace Enable
+{
+  bool BARREL = false;
+  bool BARREL_ABSORBER = false;
+}  // namespace Enable
+
+namespace G4BARREL
+{
+  namespace SETTING
+  {
+    bool BARRELV0 = false;
+    bool BARRELV1 = false;
+    bool BARRELV2 = false;
+    bool BARRELV3 = false;
+    bool BARRELV4 = false;
+    bool BARRELV5 = false;
+    bool BARRELV6 = false;
+  }  // namespace SETTING
+}  // namespace G4BARREL
+//---------------------------------------------------------------------//
+void BarrelInit()
+{
+  //check barrel setting
+  if ((G4BARREL::SETTING::BARRELV0 ? 1 : 0) +
+          (G4BARREL::SETTING::BARRELV1 ? 1 : 0) +
+          (G4BARREL::SETTING::BARRELV2 ? 1 : 0) +
+          (G4BARREL::SETTING::BARRELV3 ? 1 : 0) +
+          (G4BARREL::SETTING::BARRELV4 ? 1 : 0) +
+          (G4BARREL::SETTING::BARRELV5 ? 1 : 0) +
+          (G4BARREL::SETTING::BARRELV6 ? 1 : 0) >
+      1)
+  {
+    cout << "use only ";
+    for (int i = 0; i < 7; i++)
+    {
+      if (i == 0)
+        cout << "G4BARREL::SETTING::BARRELV" << i << "=true ";
+      else
+        cout << " or G4BARREL::SETTING::BARRELV" << i << "=true ";
+    }
+
+    gSystem->Exit(1);
+  }
+}
+
+//---------------------------------------------------------------------//
+double Barrel(PHG4Reco *g4Reco, double radius)
+{
+  const bool AbsorberActive = Enable::ABSORBER || Enable::BARREL_ABSORBER;
+  double max_bh_radius = 0.;
+
+  //---------------------------------
+  //build barrel detector
+  //---------------------------------
+  int nLayer = 5;
+  const float um = 0.0001;  //convert um to cm
+
+  // Different Barrel versions documented in arXiv:2009.02888
+  double r[6] = {3.64, 4.81, 5.98, 16.0, 22.0, -1};  //cm
+  double halfLength[6] = {20, 20, 25, 25, 25, 25};   //cm
+  double tSilicon[6] = {100 * um, 100 * um, 100 * um, 100 * um, 100 * um, 100 * um};
+  double tAirgap[6] = {0.9, 0.9, 1, 1, 1, 1};
+
+  if (G4BARREL::SETTING::BARRELV1 || G4BARREL::SETTING::BARRELV2)
+  {
+    for (Int_t i = 0; i < 3; i++) tSilicon[i] = 50 * um;
+  }
+  else if (G4BARREL::SETTING::BARRELV3)
+  {
+    for (Int_t i = 0; i < 5; i++) tSilicon[i] = 35 * um;
+  }
+  else if (G4BARREL::SETTING::BARRELV4)
+  {
+    for (Int_t i = 0; i < 3; i++) tSilicon[i] = 50 * um;
+    nLayer = 6;
+    r[3] = 9.2;
+    r[4] = 17.;
+    r[5] = 27.;
+  }
+
+  if (G4BARREL::SETTING::BARRELV5 || G4BARREL::SETTING::BARRELV6)
+  {
+    int nLayer1 = 3;                               //barrel 1
+    int nLayer2 = 2;                               //barrel 2
+    if (G4BARREL::SETTING::BARRELV6) nLayer2 = 1;  //compactible w/ TPC
+
+    int my_nLayer[2] = {nLayer1, nLayer2};
+
+    double my_r[2][3] = {{3.64, 4.81, 5.98},  //cm, barrel1
+                         {16, 22.0}};         //barrel 2
+
+    double my_halfLength[2][3] = {{20, 20, 25},  //cm, barrel 1
+                                  {25, 25}};     //barrel 2
+
+    double my_tSilicon = 35 * um;
+
+    for (int n = 0; n < 2; n++)
+    {
+      if (n == 1) my_tSilicon = 85 * um;
+      for (int i = 0; i < my_nLayer[n]; i++)
+      {
+        make_barrel_pixel_layer(Form("BARREL%d_%d", n, i), g4Reco, my_r[n][i], my_halfLength[n][i], my_tSilicon, tAirgap[i]);
+      }
+    }
+
+    // update now that we know the outer radius
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, max_bh_radius);
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, halfLength[nLayer1 + nLayer2 - 1]);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -halfLength[nLayer1 + nLayer2 - 1]);
+
+    max_bh_radius = my_r[1][nLayer2 - 1] + 1.5;
+    return max_bh_radius;
+  }
+  else
+  {  //ver 0 - 4
+    for (int i = 0; i < nLayer; i++)
+    {
+      make_barrel_pixel_layer(Form("BARREL_%d", i), g4Reco, r[i], halfLength[i], tSilicon[i], 1);
+      max_bh_radius = r[i] + 1.5;
+      //std::cout << "done with barrel layer intialization at "<< r[i] << std::endl;
+    }
+
+    // update now that we know the outer radius
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, max_bh_radius);
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, halfLength[nLayer - 1]);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -halfLength[nLayer - 1]);
+    return max_bh_radius;
+  }
+
+  return 0;
+}
+//-----------------------------------------------------------------------------------//
+int make_barrel_pixel_layer(const string &name, PHG4Reco *g4Reco,
+                            double radius, double halflength, double tSilicon, double tAirgap)
+{
+  //---------------------------------
+  //build barrel layer
+  //---------------------------------
+  const int nSubLayer = 7;
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
+
+  string layerName[nSubLayer] = {"SiliconSensor", "Metalconnection", "HDI", "Cooling",
+                                 "Support1", "Support_Gap", "Support2"};
+  string material[nSubLayer] = {"G4_Si", "G4_Al", "G4_KAPTON", "G4_WATER",
+                                "G4_GRAPHITE", "G4_AIR", "G4_GRAPHITE"};
+  double thickness[nSubLayer] = {tSilicon, 15 * um, 20 * um, 100 * um,
+                                 50 * um, tAirgap, 50 * um};
+
+  double max_bh_radius = 0.;
+  PHG4CylinderSubsystem *cyl;
+  cout << "started to create cylinder layer: " << name << endl;
+
+  double currRadius = radius;
+  //   cout << currRadius << endl;
+  for (int l = 0; l < nSubLayer; l++)
+  {
+    cout << name << "_" << layerName[l] << "\t" << currRadius;
+    cyl = new PHG4CylinderSubsystem(name + "_" + layerName[l], l);
+    cyl->SuperDetector(name);
+    cyl->set_double_param("radius", currRadius);
+    cyl->set_double_param("length", 2.0 * halflength);
+    cyl->set_string_param("material", material[l]);
+    cyl->set_double_param("thickness", thickness[l]);
+    if (l == 0) cyl->SetActive();  //only the Silicon Sensor is active
+    cyl->OverlapCheck(true);
+    g4Reco->registerSubsystem(cyl);
+    currRadius = currRadius + thickness[l];
+    cout << "\t" << currRadius << endl;
+  }
+
+  return 0;
+}
+
+//-----------------------------------------------------------------------------------//
+
+#endif

--- a/common/G4_CEmc_EIC.C
+++ b/common/G4_CEmc_EIC.C
@@ -1,0 +1,342 @@
+#ifndef MACRO_G4CEMCEIC_C
+#define MACRO_G4CEMCEIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4calo/RawTowerBuilder.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4detectors/PHG4CylinderCellReco.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <caloreco/RawClusterBuilderGraph.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+#include <cmath>
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+
+namespace Enable
+{
+  bool CEMC = false;
+  bool CEMC_ABSORBER = false;
+  bool CEMC_OVERLAPCHECK = false;
+  bool CEMC_CELL = false;
+  bool CEMC_TOWER = false;
+  bool CEMC_CLUSTER = false;
+  bool CEMC_EVAL = false;
+  int CEMC_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4CEMC
+{
+  double cemcdepth = 9;
+  // tungs to scint width ratio of ~10:1
+  // corresponds to approx 2% sampling fraction
+
+  // 18 radiation lengths for 40 layers
+  double scint_width = 0.05;
+  double tungs_width = 0.245;
+  double electronics_width = 0.5;
+
+  int min_cemc_layer = 1;
+  int max_cemc_layer = 41;
+
+  double topradius = 106.8;  // cm
+  double bottomradius = 95;  // cm
+  double negrapidity = -1.5;
+  double posrapidity = 1.24;
+  // this is default set to -1.5<eta<1.24 for 2018 Letter of Intent
+  // if the user changes these, the z position of the
+  // calorimeter must be changed in the function CEmc(...)
+
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
+  enum enu_Cemc_clusterizer
+  {
+    kCemcGraphClusterizer,
+
+    kCemcTemplateClusterizer
+  };
+
+  // default: template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
+  enu_Cemc_clusterizer Cemc_clusterizer = kCemcTemplateClusterizer;
+  // graph clusterizer, RawClusterBuilderGraph
+  // enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
+}  // namespace G4CEMC
+
+namespace CEMC_TOWER
+{
+  double emin = NAN;
+}
+
+// Black hole and size parameters set in CEmc function
+void CEmcInit(const int nslats = 1)
+{
+}
+
+double CEmc(PHG4Reco *g4Reco, double radius)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::CEMC_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::CEMC_OVERLAPCHECK;
+
+  if (radius > 95)
+  {
+    cout << "inconsistency, radius: " << radius
+         << " larger than allowed inner radius for CEMC = 95 cm" << endl;
+    gSystem->Exit(-1);
+  }
+
+  radius = 95;
+
+  PHG4CylinderSubsystem *cemc;
+
+  // determine the length of the calorimeter
+  // can adjust length coverage by just adjusting these values
+  // rapidity coverage will be determined by z shift of EMCAl
+  // as indicated in the loop below
+
+  // eta = -ln(tan(theta/2))
+  double theta1 = 2. * TMath::ATan(TMath::Exp(-1 * G4CEMC::posrapidity));
+  double theta2 = 2. * TMath::ATan(TMath::Exp(-1 * G4CEMC::negrapidity));
+  // get the angle between the beam pipe and negative pseudorapidity axis
+  theta2 = M_PI - theta2;
+
+  double z1 = G4CEMC::topradius / TMath::Tan(theta1);
+  double z2 = G4CEMC::topradius / TMath::Tan(theta2);
+
+  double z3 = G4CEMC::bottomradius / TMath::Tan(theta1);
+  double z4 = G4CEMC::bottomradius / TMath::Tan(theta2);
+
+  // this is the top layer length
+  double totaltoplength = z1 + z2;
+  // this is the bottom layer length
+  double totalbottomlength = z3 + z4;
+
+  //Added by Barak, 12/12/19
+  double ztemp = 0;
+  double layer_shift = 0;
+
+  double height = 0;
+  for (int thislayer = G4CEMC::min_cemc_layer; thislayer <= G4CEMC::max_cemc_layer;
+       thislayer++)
+  {
+    // the length for a particular layer is determined from the bottom length
+    double thislength = totalbottomlength + (height / TMath::Tan(theta1)) + (height / TMath::Tan(theta2));
+
+    cemc = new PHG4CylinderSubsystem("ABSORBER_CEMC", thislayer);
+    cemc->set_double_param("radius", radius);
+    cemc->set_string_param("material", "Spacal_W_Epoxy");
+    cemc->set_double_param("thickness", G4CEMC::tungs_width);
+    cemc->set_double_param("length", thislength);
+    cemc->set_int_param("lengthviarapidity", 0);
+
+    // starts centered around IP
+    // shift backwards 30 cm for total 370 cm length to cover -1.5<eta<1.24
+    //cemc->set_double_param("place_z", -30);
+
+    //Modified by Barak, 12/12/19
+    ztemp = radius / TMath::Tan(theta2);
+    layer_shift = -1. * (ztemp - (thislength / 2.));
+    cemc->set_double_param("place_z", layer_shift);
+
+    cemc->SuperDetector("ABSORBER_CEMC");
+    if (AbsorberActive) cemc->SetActive();
+    cemc->OverlapCheck(OverlapCheck);
+
+    g4Reco->registerSubsystem(cemc);
+
+    radius += G4CEMC::tungs_width;
+    radius += no_overlapp;
+
+    height += G4CEMC::tungs_width;
+    height += no_overlapp;  //Added by Barak, 12/13/19
+
+    //Added by Barak, 12/13/19
+    thislength = totalbottomlength + (height / TMath::Tan(theta1)) + (height / TMath::Tan(theta2));
+
+    cemc = new PHG4CylinderSubsystem("CEMC", thislayer);
+    cemc->set_double_param("radius", radius);
+    cemc->set_string_param("material", "PMMA");
+    cemc->set_double_param("thickness", G4CEMC::scint_width);
+    cemc->set_int_param("lightyield", 1);
+    cemc->set_int_param("lengthviarapidity", 0);
+    cemc->set_double_param("length", thislength);
+
+    // shift back -30 cm to cover -1.4<eta<1.1
+    //cemc->set_double_param("place_z", -30);
+
+    //Modified by Barak, 12/12/19
+    cemc->set_double_param("place_z", layer_shift);
+
+    cemc->SuperDetector("CEMC");
+
+    cemc->SetActive();
+    cemc->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cemc);
+
+    radius += G4CEMC::scint_width;
+    radius += no_overlapp;
+
+    height += G4CEMC::scint_width;
+    height += no_overlapp;  //Added by Barak, 12/13/19
+  }
+
+  PHG4CylinderSubsystem *cemc_cyl = new PHG4CylinderSubsystem("CEMC_ELECTRONICS", 0);
+  cemc_cyl->set_double_param("radius", radius);
+  cemc_cyl->set_string_param("material", "G4_TEFLON");
+  cemc_cyl->set_double_param("thickness", G4CEMC::electronics_width);
+
+  double l1 = (radius + 0.5) / TMath::Tan(theta1);
+  double l2 = (radius + 0.5) / TMath::Tan(theta2);
+  cemc_cyl->set_int_param("lengthviarapidity", 0);
+  cemc_cyl->set_double_param("length", l1 + l2);
+  // shift back -30 cm to cover -1.4<eta<1.1
+  //cemc_cyl->set_double_param("place_z", -30);
+
+  //Modified by Barak, 12/12/19
+  layer_shift = -1. * ((l2 - l1) / 2.);
+  cemc_cyl->set_double_param("place_z", layer_shift);
+
+  if (AbsorberActive) cemc_cyl->SetActive();
+  cemc_cyl->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(cemc_cyl);
+  // update black hole settings since we have the values here
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, radius + G4CEMC::electronics_width);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, layer_shift + (l1 + l2) / 2.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, layer_shift - (l1 + l2) / 2.);
+
+  return radius;
+}
+
+void CEMC_Cells()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4CylinderCellReco *cemc_cells = new PHG4CylinderCellReco("CEMCCYLCELLRECO");
+  cemc_cells->Detector("CEMC");
+  cemc_cells->Verbosity(verbosity);
+  double radius = 95;
+  for (int i = G4CEMC::min_cemc_layer; i <= G4CEMC::max_cemc_layer; i++)
+  {
+    //Added by Barak, 12/13/19
+    radius += (G4CEMC::tungs_width + no_overlapp);
+    if (i > 1) radius += (G4CEMC::scint_width + no_overlapp);
+
+    cemc_cells->cellsize(i, 2. * M_PI / 256. * radius, 2. * M_PI / 256. * radius);
+  }
+  se->registerSubsystem(cemc_cells);
+
+  return;
+}
+
+void CEMC_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  RawTowerBuilder *CemcTowerBuilder = new RawTowerBuilder("EmcRawTowerBuilder");
+  CemcTowerBuilder->Detector("CEMC");
+  CemcTowerBuilder->set_sim_tower_node_prefix("SIM");
+  if (isfinite(CEMC_TOWER::emin))
+  {
+    CemcTowerBuilder->EminCut(CEMC_TOWER::emin);
+  }
+  CemcTowerBuilder->Verbosity(verbosity);
+  se->registerSubsystem(CemcTowerBuilder);
+
+  const double photoelectron_per_GeV = 500;  // 500 photon per total GeV deposition
+  // just set a 4% sampling fraction - already tuned by tungs/scint width ratio
+  double sampling_fraction = 4e-02;
+  RawTowerDigitizer *CemcTowerDigitizer = new RawTowerDigitizer("EmcRawTowerDigitizer");
+  CemcTowerDigitizer->Detector("CEMC");
+  CemcTowerDigitizer->Verbosity(verbosity);
+  CemcTowerDigitizer->set_digi_algorithm(G4CEMC::TowerDigi);
+  CemcTowerDigitizer->set_pedstal_central_ADC(0);
+  CemcTowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+  CemcTowerDigitizer->set_photonelec_ADC(1);     // not simulating ADC discretization error
+  CemcTowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
+  CemcTowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+  se->registerSubsystem(CemcTowerDigitizer);
+
+  RawTowerCalibration *CemcTowerCalibration = new RawTowerCalibration("EmcRawTowerCalibration");
+  CemcTowerCalibration->Detector("CEMC");
+  CemcTowerCalibration->Verbosity(verbosity);
+  CemcTowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  if (G4CEMC::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    CemcTowerCalibration->set_calib_const_GeV_ADC(1.0 / 0.023);  // 2.3% sampling fraction from test beam
+  }
+  else
+  {
+    CemcTowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);
+  }
+  CemcTowerCalibration->set_pedstal_ADC(0);
+
+  se->registerSubsystem(CemcTowerCalibration);
+
+  return;
+}
+
+void CEMC_Clusters()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4CEMC::Cemc_clusterizer == G4CEMC::kCemcTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *cemc_clusterbuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplate");
+    cemc_clusterbuilder->Detector("CEMC");
+    cemc_clusterbuilder->Verbosity(verbosity);
+
+    cemc_clusterbuilder->set_threshold_energy(0.030);  // This threshold should be the same as in CEMCprof_Thresh**.root file below
+    std::string femc_prof = getenv("CALIBRATIONROOT");
+    femc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
+    cemc_clusterbuilder->LoadProfile(femc_prof);
+    se->registerSubsystem(cemc_clusterbuilder);
+  }
+  else if (G4CEMC::Cemc_clusterizer == G4CEMC::kCemcGraphClusterizer)
+  {
+    RawClusterBuilderGraph *cemc_clusterbuilder = new RawClusterBuilderGraph("EmcRawClusterBuilderGraph");
+    cemc_clusterbuilder->Detector("CEMC");
+    cemc_clusterbuilder->Verbosity(verbosity);
+    se->registerSubsystem(cemc_clusterbuilder);
+  }
+  else
+  {
+    cout << "CEMC_Clusters - unknown clusterizer setting!! " << endl;
+    exit(1);
+  }
+  return;
+}
+void CEMC_Eval(const std::string &outputfile)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+  CaloEvaluator *eval = new CaloEvaluator("CEMCEVALUATOR", "CEMC", outputfile.c_str());
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+  return;
+}
+#endif

--- a/common/G4_DIRC.C
+++ b/common/G4_DIRC.C
@@ -1,0 +1,106 @@
+#ifndef MACRO_G4DIRC_C
+#define MACRO_G4DIRC_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4SectorSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <cmath>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+/*!
+ * \file G4_DIRC.C
+ * \brief Macro setting up the barrel DIRC
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.3 $
+ * \date $Date: 2013/10/09 01:08:17 $
+ */
+
+namespace Enable
+{
+  bool DIRC = false;
+  bool DIRC_OVERLAPCHECK = false;
+}  // namespace Enable
+
+namespace G4DIRC
+{
+  double radiator_R = 83.65;
+  double length = 400;
+  double z_shift = -75;  //115
+  double z_start = z_shift + length / 2.;
+  double z_end = z_shift - length / 2.;
+  double outer_skin_radius = 89.25;
+}  // namespace G4DIRC
+
+void DIRCInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4DIRC::outer_skin_radius);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4DIRC::z_start);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, G4DIRC::z_end);
+}
+
+//! Babar DIRC (Without most of support structure)
+//! Ref: I. Adam et al. The DIRC particle identification system for the BaBar experiment.
+//! Nucl. Instrum. Meth., A538:281-357, 2005. doi:10.1016/j.nima.2004.08.129.
+double DIRCSetup(PHG4Reco *g4Reco)
+{
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::DIRC_OVERLAPCHECK;
+
+  PHG4SectorSubsystem *dirc;
+  dirc = new PHG4SectorSubsystem("DIRC");
+  dirc->get_geometry().set_normal_polar_angle(M_PI / 2);
+  dirc->get_geometry().set_normal_start(83.65 * PHG4Sector::Sector_Geometry::Unit_cm());
+  dirc->get_geometry().set_min_polar_angle(atan2(G4DIRC::radiator_R, G4DIRC::z_start));
+  dirc->get_geometry().set_max_polar_angle(atan2(G4DIRC::radiator_R, G4DIRC::z_end));
+  dirc->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  dirc->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  dirc->get_geometry().set_material("Quartz");
+  dirc->get_geometry().set_N_Sector(12);
+  dirc->OverlapCheck(OverlapCheck);
+  dirc->get_geometry().AddLayer("Radiator", "Quartz", 1.7 * PHG4Sector::Sector_Geometry::Unit_cm(), true);
+  g4Reco->registerSubsystem(dirc);
+
+  PHG4CylinderSubsystem *cyl;
+
+  //  The cylinder skins provide most of the strength
+  //  and stiffness of the CST. The thickness of the inner
+  //  and outer skins is 1.27 and 0.76 mm, respectively
+
+  // Inner skin:
+  cyl = new PHG4CylinderSubsystem("DIRC_CST_Inner_Skin", 10);
+  cyl->set_double_param("radius", 81.71);
+  cyl->set_double_param("length", G4DIRC::length);
+  cyl->set_string_param("material", "G4_Al");
+  cyl->set_double_param("thickness", 0.127);
+  cyl->set_double_param("place_x", 0.);
+  cyl->set_double_param("place_y", 0.);
+  cyl->set_double_param("place_z", G4DIRC::z_shift);
+  cyl->SetActive(0);
+  cyl->SuperDetector("DIRC");
+  cyl->OverlapCheck(OverlapCheck);
+
+  g4Reco->registerSubsystem(cyl);
+
+  // Outer skin:
+  cyl = new PHG4CylinderSubsystem("DIRC_CST_Outer_Skin", 11);
+  cyl->set_double_param("radius", G4DIRC::outer_skin_radius - 0.076);
+  cyl->set_double_param("length", G4DIRC::length);
+  cyl->set_string_param("material", "G4_Al");
+  cyl->set_double_param("thickness", 0.076);
+  cyl->set_double_param("place_x", 0.);
+  cyl->set_double_param("place_y", 0.);
+  cyl->set_double_param("place_z", G4DIRC::z_shift);
+  cyl->SetActive(0);
+  cyl->SuperDetector("DIRC");
+  cyl->OverlapCheck(OverlapCheck);
+
+  g4Reco->registerSubsystem(cyl);
+
+  // Done
+  return G4DIRC::outer_skin_radius;
+}
+#endif

--- a/common/G4_DRCALO.C
+++ b/common/G4_DRCALO.C
@@ -1,0 +1,195 @@
+#ifndef MACRO_G4DR_C
+#define MACRO_G4DR_C
+
+#include <GlobalVariables.C>
+
+#include <g4calo/RawTowerBuilderDRCALO.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <drcalo/PHG4ForwardDualReadoutSubsystem.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+
+namespace Enable
+{
+  bool DRCALO = false;
+  bool DRCALO_ABSORBER = false;
+  bool DRCALO_CELL = false;
+  bool DRCALO_TOWER = false;
+  bool DRCALO_CLUSTER = false;
+  bool DRCALO_EVAL = false;
+  bool DRCALO_OVERLAPCHECK = false;
+  int DRCALO_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4DRCALO
+{
+  // from ForwardDualReadout/mapping/towerMap_DRCALO_v005.txt
+  double Gz0 = 400.;
+  double Gdz = 100.;
+  double outer_radius = 262.;
+  enum enu_FHcal_clusterizer
+  {
+    kFHcalGraphClusterizer,
+    kFHcalTemplateClusterizer
+  };
+  //template clusterizer, as developed by Sasha Bazilevsky
+  enu_FHcal_clusterizer FHcal_clusterizer = kFHcalTemplateClusterizer;
+  // graph clusterizer
+  //enu_FHcal_clusterizer FHcal_clusterizer = kFHcalGraphClusterizer;
+  namespace SETTING
+  {
+    bool ECalReplace = false;
+    bool LargeTowers = false;
+  }  // namespace SETTING
+}  // namespace G4DRCALO
+
+void DRCALOInit()
+{
+  // simple way to check if only 1 of the settings is true
+  if (( (G4DRCALO::SETTING::ECalReplace ? 1 : 0) + (G4DRCALO::SETTING::LargeTowers ? 1 : 0)) > 1)
+  {
+    cout << "use only  G4DRCALO::SETTING::FullEtaAcc=true or G4DRCALO::SETTING::HC2x=true or G4DRCALO::SETTING::HC4x=true" << endl;
+    gSystem->Exit(1);
+  }
+
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4DRCALO::outer_radius);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4DRCALO::Gz0 + G4DRCALO::Gdz / 2.);
+}
+
+void DRCALOSetup(PHG4Reco *g4Reco)
+{
+  const bool AbsorberActive = Enable::ABSORBER || Enable::DRCALO_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::DRCALO_OVERLAPCHECK;
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  /** Use dedicated DRCALO module */
+  PHG4ForwardDualReadoutSubsystem *hhcal = new PHG4ForwardDualReadoutSubsystem("DRCALO");
+  hhcal->OverlapCheck(OverlapCheck);
+  hhcal->SuperDetector("DRCALO");
+  hhcal->SetActive();
+
+  ostringstream mapping_drcalo;
+
+  // Switch to desired calo setup
+  // full HCal Fe-Scint with nominal acceptance
+  if (G4DRCALO::SETTING::LargeTowers)
+    mapping_drcalo << getenv("CALIBRATIONROOT") << "/DRCALO/mapping/towerMap_DRCALO_large_tower.txt";
+    // mapping_drcalo << getenv("EICCONFIGS") << "/towerMap_DRCALO_default_singleTower.txt";
+  // full HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+    mapping_drcalo << getenv("CALIBRATIONROOT") << "/DRCALO/mapping/towerMap_DRCALO_default.txt";
+    // mapping_drcalo << getenv("EICCONFIGS") << "/towerMap_DRCALO_replaceEMC.txt";
+
+  hhcal->SetTowerMappingFile(mapping_drcalo.str());
+
+
+  if (AbsorberActive) hhcal->SetAbsorberActive();
+
+  g4Reco->registerSubsystem(hhcal);
+}
+
+void DRCALO_Cells(int verbosity = 0)
+{
+  return;
+}
+
+void DRCALO_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::DRCALO_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  ostringstream mapping_drcalo;
+
+  // Switch to desired calo setup
+  // full HCal Fe-Scint with nominal acceptance
+  if (G4DRCALO::SETTING::LargeTowers)
+    mapping_drcalo << getenv("CALIBRATIONROOT") << "/DRCALO/mapping/towerMap_DRCALO_large_tower.txt";
+    // mapping_drcalo << getenv("EICCONFIGS") << "/towerMap_DRCALO_default_singleTower.txt";
+  // full HCal Fe-Scint with nominal acceptance doubled granularity
+  else
+    mapping_drcalo << getenv("CALIBRATIONROOT") << "/DRCALO/mapping/towerMap_DRCALO_default.txt";
+    // mapping_drcalo << getenv("EICCONFIGS") << "/towerMap_DRCALO_replaceEMC.txt";
+
+
+  RawTowerBuilderDRCALO *tower_DRCALO = new RawTowerBuilderDRCALO("TowerBuilder_DRCALO");
+  tower_DRCALO->Detector("DRCALO");
+  tower_DRCALO->set_sim_tower_node_prefix("SIM");
+  tower_DRCALO->GeometryTableFile(mapping_drcalo.str());
+
+  se->registerSubsystem(tower_DRCALO);
+
+  cout << "def: using default for DRCALO towers" << endl;
+  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("DRCALORawTowerDigitizer");
+  TowerDigitizer->Detector("DRCALO");
+  TowerDigitizer->Verbosity(1);
+  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  se->registerSubsystem(TowerDigitizer);
+
+  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("DRCALORawTowerCalibration");
+  TowerCalibration->Detector("DRCALO");
+  TowerCalibration->Verbosity(verbosity);
+  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration->set_calib_const_GeV_ADC(1. / 0.03898);  // calibrated with muons
+  TowerCalibration->set_pedstal_ADC(0);
+  se->registerSubsystem(TowerCalibration);
+}
+
+void DRCALO_Clusters()
+{
+  // int verbosity = std::max(Enable::VERBOSITY, Enable::DRCALO_VERBOSITY);
+  // Fun4AllServer *se = Fun4AllServer::instance();
+
+  // if (G4DRCALO::FHcal_clusterizer == G4DRCALO::kFHcalTemplateClusterizer)
+  // {
+  //   RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("DRCALORawClusterBuilderTemplate");
+  //   ClusterBuilder->Detector("DRCALO");
+  //   ClusterBuilder->SetPlanarGeometry();  // has to be called after Detector()
+  //   ClusterBuilder->Verbosity(verbosity);
+  //   ClusterBuilder->set_threshold_energy(0.100);
+  //   se->registerSubsystem(ClusterBuilder);
+  // }
+  // else if (G4DRCALO::FHcal_clusterizer == G4DRCALO::kFHcalTemplateClusterizer)
+  // {
+  //   RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("DRCALORawClusterBuilderFwd");
+  //   ClusterBuilder->Detector("DRCALO");
+  //   ClusterBuilder->Verbosity(verbosity);
+  //   ClusterBuilder->set_threshold_energy(0.100);
+  //   se->registerSubsystem(ClusterBuilder);
+  // }
+  // else
+  // {
+  //   cout << "DRCALO_Clusters - unknown clusterizer setting " << G4DRCALO::FHcal_clusterizer << endl;
+  //   gSystem->Exit(1);
+  // }
+
+  return;
+}
+
+void DRCALO_Eval(const std::string &outputfile)
+{
+  // int verbosity = std::max(Enable::VERBOSITY, Enable::DRCALO_VERBOSITY);
+  // Fun4AllServer *se = Fun4AllServer::instance();
+
+  // CaloEvaluator *eval = new CaloEvaluator("DRCALOEVALUATOR", "DRCALO", outputfile.c_str());
+  // eval->Verbosity(verbosity);
+  // se->registerSubsystem(eval);
+
+  return;
+}
+#endif

--- a/common/G4_DSTReader_EICDetector.C
+++ b/common/G4_DSTReader_EICDetector.C
@@ -1,0 +1,251 @@
+#ifndef MACRO_G4DSTREADEREICDETECTOR_C
+#define MACRO_G4DSTREADEREICDETECTOR_C
+
+#include <GlobalVariables.C>
+
+#include <G4_Barrel_EIC.C>
+#include <G4_CEmc_EIC.C>
+#include <G4_DIRC.C>
+#include <G4_EEMC.C>
+#include <G4_FEMC_EIC.C>
+#include <G4_FHCAL.C>
+#include <G4_FST_EIC.C>
+#include <G4_GEM_EIC.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx_EIC.C>
+#include <G4_RICH.C>
+#include <G4_TPC_EIC.C>
+
+#include <g4eval/PHG4DSTReader.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libg4eval.so)
+
+//////////////////////////////////////////////////////////////////
+/*!
+  \file G4_DSTReader.C
+  \brief Convert DST to human command readable TTree for quick poke around the outputs
+  \author  Jin Huang
+  \version $Revision:  $
+  \date    $Date: $
+*/
+//////////////////////////////////////////////////////////////////
+namespace Enable
+{
+  bool DSTREADER = false;
+  int DSTREADER_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4DSTREADER
+{
+  bool save_g4_raw = true;
+  double tower_zero_supp = 1.e-6;
+}  // namespace G4DSTREADER
+
+void G4DSTreader_EICDetectorInit() {}
+void G4DSTreader_EICDetector(const string &outputFile = "G4sPHENIXCells.root")
+{
+  //! debug output on screen?
+  int verbosity = max(Enable::VERBOSITY, Enable::DSTREADER_VERBOSITY);
+
+  // save a comprehensive  evaluation file
+  PHG4DSTReader *ana = new PHG4DSTReader(outputFile);
+  ana->set_save_particle(true);
+  ana->set_load_all_particle(false);
+  ana->set_load_active_particle(true);
+  ana->set_save_vertex(true);
+
+  ana->Verbosity(verbosity);
+
+  if (G4DSTREADER::save_g4_raw)
+  {
+    if (Enable::PIPE && Enable::PIPE_ABSORBER)
+    {
+      ana->AddNode("PIPE");
+    }
+    if (Enable::BARREL)
+    {
+      if (G4BARREL::SETTING::BARRELV5 ||G4BARREL::SETTING::BARRELV6) {
+	int nLayer1 = 3;   //barrel 1                                                                                                      
+	int nLayer2 = 2;   //barrel 2                                                                                                      
+	if (G4BARREL::SETTING::BARRELV6) nLayer2 = 1;  //compactible w/ TPC                                                                
+	int nLayer[2]={nLayer1,nLayer2};
+
+	for (int n=0;n<2;n++) 
+	{
+	  for (int i;i<nLayer[n];i++) 
+	  {
+	    ana->AddNode(Form("BARREL%d_%d",n,i));
+	  }
+	}
+      }
+      else
+      {
+	int nLayer=5;
+	if (G4BARREL::SETTING::BARRELV4) nLayer=6;
+	for (int i;i<nLayer;i++)
+	{
+	  ana->AddNode(Form("BARREL%d",i));
+	}
+      }
+    }	
+    if (Enable::MVTX)
+    {
+      ana->AddNode("MVTX");
+    }
+    if (Enable::TPC)
+    {
+      ana->AddNode("TPC");
+    }
+
+    if (Enable::EGEM)
+    {
+      ana->AddNode("EGEM_0");
+      ana->AddNode("EGEM_1");
+      ana->AddNode("EGEM_2");
+      ana->AddNode("EGEM_3");
+    }
+    if (Enable::FGEM)
+    {
+      ana->AddNode("FGEM_2");
+      ana->AddNode("FGEM_3");
+      ana->AddNode("FGEM_4");
+    }
+    if (Enable::FST)
+    {
+      ana->AddNode("FST_0");
+      ana->AddNode("FST_1");
+      ana->AddNode("FST_2");
+      ana->AddNode("FST_3");
+      ana->AddNode("FST_4");
+      if (G4FST::SETTING::FSTV4 || G4FST::SETTING::FSTV5)
+      {
+	ana->AddNode("FST_5");
+      }
+    }
+
+    if (Enable::CEMC)
+    {
+      ana->AddNode("CEMC");
+      if (Enable::ABSORBER || Enable::CEMC_ABSORBER)
+      {
+        ana->AddNode("ABSORBER_CEMC");
+        ana->AddNode("CEMC_ELECTRONICS_0");
+      }
+    }
+
+    if (Enable::HCALIN)
+    {
+      ana->AddNode("HCALIN");
+      if (Enable::ABSORBER || Enable::HCALIN_ABSORBER)
+      {
+        ana->AddNode("ABSORBER_HCALIN");
+        ana->AddNode("HCALIN_SPT");
+      }
+    }
+
+    if (Enable::MAGNET)
+    {
+      if (Enable::ABSORBER || Enable::MAGNET_ABSORBER)
+        ana->AddNode("MAGNET");
+    }
+
+    if (Enable::HCALOUT)
+    {
+      ana->AddNode("HCALOUT");
+      if (Enable::ABSORBER || Enable::HCALOUT_ABSORBER)
+        ana->AddNode("ABSORBER_HCALOUT");
+    }
+
+    if (Enable::FHCAL)
+    {
+      ana->AddNode("FHCAL");
+      if (Enable::ABSORBER || Enable::FHCAL_ABSORBER)
+        ana->AddNode("ABSORBER_FHCAL");
+    }
+
+    if (Enable::FEMC)
+    {
+      ana->AddNode("FEMC");
+      if (Enable::ABSORBER || Enable::FEMC_ABSORBER)
+        ana->AddNode("ABSORBER_FEMC");
+    }
+
+    if (Enable::EEMC)
+    {
+      ana->AddNode("EEMC");
+    }
+    if (Enable::DIRC)
+    {
+      ana->AddNode("DIRC");
+    }
+    if (Enable::RICH)
+    {
+      ana->AddNode("RICH");
+    }
+
+    if (Enable::BLACKHOLE)
+    {
+      ana->AddNode("BH_1");
+      ana->AddNode("BH_FORWARD_PLUS");
+      ana->AddNode("BH_FORWARD_NEG");
+    }
+  }
+
+  ana->set_tower_zero_sup(G4DSTREADER::tower_zero_supp);
+  if (Enable::CEMC_TOWER)
+  {
+    ana->AddTower("SIM_CEMC");
+    ana->AddTower("RAW_CEMC");
+    ana->AddTower("CALIB_CEMC");
+  }
+  if (Enable::HCALIN_TOWER)
+  {
+    ana->AddTower("SIM_HCALIN");
+    ana->AddTower("RAW_HCALIN");
+    ana->AddTower("CALIB_HCALIN");
+  }
+  if (Enable::HCALOUT_TOWER)
+  {
+    ana->AddTower("SIM_HCALOUT");
+    ana->AddTower("RAW_HCALOUT");
+    ana->AddTower("CALIB_HCALOUT");
+  }
+  if (Enable::FHCAL_TOWER)
+  {
+    ana->AddTower("SIM_FHCAL");
+    ana->AddTower("RAW_FHCAL");
+    ana->AddTower("CALIB_FHCAL");
+  }
+  if (Enable::FEMC_TOWER)
+  {
+    ana->AddTower("SIM_FEMC");
+    ana->AddTower("RAW_FEMC");
+    ana->AddTower("CALIB_FEMC");
+  }
+  if (Enable::EEMC_TOWER)
+  {
+    ana->AddTower("SIM_EEMC");
+    ana->AddTower("RAW_EEMC");
+    ana->AddTower("CALIB_EEMC");
+  }
+
+  // Jets disabled for now
+  //  if (do_jet_reco)
+  //    {
+  //
+  //      ana->AddJet("AntiKt06JetsInPerfect");
+  //      ana->AddJet("G4TowerJets_6");
+  //    }
+  //  if (embed_input_file && do_jet_reco)
+  //    {
+  //      ana->AddJet("G4TowerJets_combined_6");
+  //    }
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->registerSubsystem(ana);
+}
+#endif

--- a/common/G4_DSTReader_fsPHENIX.C
+++ b/common/G4_DSTReader_fsPHENIX.C
@@ -1,0 +1,184 @@
+#ifndef MACRO_G4DSTREADERFSPHENIX_C
+#define MACRO_G4DSTREADERFSPHENIX_C
+
+#include <GlobalVariables.C>
+
+#include <G4_CEmc_Spacal.C>
+#include <G4_FEMC.C>
+#include <G4_FGEM_fsPHENIX.C>
+#include <G4_FHCAL.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Intt.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx.C>
+#include <G4_TPC.C>
+
+#include <g4eval/PHG4DSTReader.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libg4eval.so)
+
+//////////////////////////////////////////////////////////////////
+/*!
+ \file G4_DSTReader.C
+ \brief Convert DST to human command readable TTree for quick poke around the outputs
+ \author  Jin Huang
+ \version $Revision:  $
+ \date    $Date: $
+ */
+//////////////////////////////////////////////////////////////////
+
+namespace Enable
+{
+  bool DSTREADER = false;
+  int DSTREADER_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4DSTREADER
+{
+  bool save_g4_raw = true;
+  double tower_zero_supp = 1.e-6;
+}  // namespace G4DSTREADER
+
+void G4DSTreader_fsPHENIXInit() {}
+
+void G4DSTreader_fsPHENIX(const string &outputFile = "G4sPHENIXCells.root")
+{
+  //! debug output on screen?
+  int verbosity = max(Enable::VERBOSITY, Enable::DSTREADER_VERBOSITY);
+
+  // save a comprehensive  evaluation file
+  PHG4DSTReader *ana = new PHG4DSTReader(outputFile);
+  ana->set_save_particle(true);
+  ana->set_load_all_particle(false);
+  ana->set_load_active_particle(true);
+  ana->set_save_vertex(true);
+
+  ana->Verbosity(verbosity);
+
+  if (G4DSTREADER::save_g4_raw)
+  {
+    if (Enable::MVTX)
+    {
+      ana->AddNode("MVTX");
+    }
+    if (Enable::INTT)
+    {
+      ana->AddNode("INTT");
+    }
+    if (Enable::TPC)
+    {
+      ana->AddNode("TPC");
+    }
+
+    if (Enable::CEMC)
+    {
+      ana->AddNode("CEMC");
+      if (Enable::ABSORBER || Enable::CEMC_ABSORBER)
+      {
+        ana->AddNode("ABSORBER_CEMC");
+        ana->AddNode("CEMC_ELECTRONICS");
+        ana->AddNode("CEMC_SPT");
+      }
+    }
+
+    if (Enable::HCALIN)
+    {
+      ana->AddNode("HCALIN");
+      if (Enable::ABSORBER || Enable::HCALIN_ABSORBER)
+        ana->AddNode("ABSORBER_HCALIN");
+    }
+
+    if (Enable::MAGNET)
+    {
+      if (Enable::ABSORBER || Enable::MAGNET_ABSORBER)
+        ana->AddNode("MAGNET");
+    }
+
+    if (Enable::HCALOUT)
+    {
+      ana->AddNode("HCALOUT");
+      if (Enable::ABSORBER || Enable::HCALOUT_ABSORBER)
+        ana->AddNode("ABSORBER_HCALOUT");
+    }
+
+    if (Enable::FHCAL)
+    {
+      ana->AddNode("FHCAL");
+      if (Enable::ABSORBER || Enable::FHCAL_ABSORBER)
+        ana->AddNode("ABSORBER_FHCAL");
+    }
+
+    if (Enable::FEMC)
+    {
+      ana->AddNode("FEMC");
+      if (Enable::ABSORBER || Enable::FEMC_ABSORBER)
+        ana->AddNode("ABSORBER_FEMC");
+    }
+
+    if (Enable::FGEM)
+    {
+      ana->AddNode("FGEM_0");
+      ana->AddNode("FGEM_1");
+      ana->AddNode("FGEM_2");
+      ana->AddNode("FGEM_3");
+      ana->AddNode("FGEM_4");
+    }
+    if (Enable::BLACKHOLE)
+    {
+      ana->AddNode("BH_1");
+      ana->AddNode("BH_FORWARD_PLUS");
+      ana->AddNode("BH_FORWARD_NEG");
+    }
+  }
+
+  ana->set_tower_zero_sup(G4DSTREADER::tower_zero_supp);
+  if (Enable::CEMC_TOWER)
+  {
+    ana->AddTower("SIM_CEMC");
+    ana->AddTower("RAW_CEMC");
+    ana->AddTower("CALIB_CEMC");
+  }
+  if (Enable::HCALIN_TOWER)
+  {
+    ana->AddTower("SIM_HCALIN");
+    ana->AddTower("RAW_HCALIN");
+    ana->AddTower("CALIB_HCALIN");
+  }
+  if (Enable::HCALOUT_TOWER)
+  {
+    ana->AddTower("SIM_HCALOUT");
+    ana->AddTower("RAW_HCALOUT");
+    ana->AddTower("CALIB_HCALOUT");
+  }
+  if (Enable::FHCAL_TOWER)
+  {
+    ana->AddTower("SIM_FHCAL");
+    ana->AddTower("RAW_FHCAL");
+    ana->AddTower("CALIB_FHCAL");
+  }
+  if (Enable::FEMC_TOWER)
+  {
+    ana->AddTower("SIM_FEMC");
+    ana->AddTower("RAW_FEMC");
+    ana->AddTower("CALIB_FEMC");
+  }
+
+  // Jets disabled for now
+  //  if (Enable::JETS)
+  //    {
+  //
+  //      ana->AddJet("AntiKt06JetsInPerfect");
+  //      ana->AddJet("G4TowerJets_6");
+  //    }
+  //  if (embed_input_file && do_jet_reco)
+  //    {
+  //      ana->AddJet("G4TowerJets_combined_6");
+  //    }
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->registerSubsystem(ana);
+}
+#endif

--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -1,0 +1,222 @@
+#ifndef MACRO_G4EEMC_C
+#define MACRO_G4EEMC_C
+
+#include <GlobalVariables.C>
+
+#include <g4calo/RawTowerBuilderByHitIndex.h>
+#include <g4calo/RawTowerDigitizer.h>
+#include <g4detectors/PHG4CrystalCalorimeterSubsystem.h>
+#include <g4detectors/PHG4ForwardCalCellReco.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+
+namespace Enable
+{
+  bool EEMC = false;
+  bool EEMC_ABSORBER = false;
+  bool EEMC_CELL = false;
+  bool EEMC_TOWER = false;
+  bool EEMC_CLUSTER = false;
+  bool EEMC_EVAL = false;
+  bool EEMC_OVERLAPCHECK = false;
+  int EEMC_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4EEMC
+{
+  int use_projective_geometry = 0;
+  double Gdz = 18. + 0.0001;
+  double Gz0 = -170.;
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
+  enum enu_Eemc_clusterizer
+  {
+    kEemcGraphClusterizer,
+    kEemcTemplateClusterizer
+  };
+  //default template clusterizer, as developed by Sasha Bazilevsky
+  enu_Eemc_clusterizer Eemc_clusterizer = kEemcTemplateClusterizer;
+  // graph clusterizer
+  //enu_Eemc_clusterizer Eemc_clusterizer = kEemcGraphClusterizer;
+
+}  // namespace G4EEMC
+
+void EEMCInit()
+{
+  if (G4EEMC::use_projective_geometry)
+  {
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 81.);
+  }
+  else
+  {
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 65.6);
+  }
+  // from towerMap_EEMC_v006.txt
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, G4EEMC::Gz0 - G4EEMC::Gdz / 2.);
+}
+
+void EEMCSetup(PHG4Reco *g4Reco)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::EEMC_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::EEMC_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::EEMC_VERBOSITY);
+
+  /** Use dedicated EEMC module */
+  PHG4CrystalCalorimeterSubsystem *eemc = new PHG4CrystalCalorimeterSubsystem("EEMC");
+  eemc->SuperDetector("EEMC");
+  eemc->SetActive();
+  if (AbsorberActive)
+  {
+    eemc->SetAbsorberActive();
+  }
+
+  /* path to central copy of calibrations repository */
+  ostringstream mapping_eemc;
+
+  /* Use non-projective geometry */
+  if (!G4EEMC::use_projective_geometry)
+  {
+    mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v006.txt";
+    eemc->set_string_param("mappingtower", mapping_eemc.str());
+  }
+
+  /* use projective geometry */
+  else
+  {
+    cout << "The projective version has serious problems with overlaps" << endl;
+    cout << "Do Not Use!" << endl;
+    cout << "If you insist, copy G4_EEMC.C locally and comment out this exit" << endl;
+    gSystem->Exit(1);
+    ostringstream mapping_eemc_4x4construct;
+
+    mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/crystals_v005.txt";
+    mapping_eemc_4x4construct << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/4_by_4_construction_v005.txt";
+    eemc->SetProjectiveGeometry(mapping_eemc.str(), mapping_eemc_4x4construct.str());
+  }
+
+  eemc->OverlapCheck(OverlapCheck);
+
+  /* register Ecal module */
+  g4Reco->registerSubsystem(eemc);
+}
+
+void EEMC_Cells()
+{
+}
+
+void EEMC_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::EEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  ostringstream mapping_eemc;
+  mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v006.txt";
+
+  RawTowerBuilderByHitIndex *tower_EEMC = new RawTowerBuilderByHitIndex("TowerBuilder_EEMC");
+  tower_EEMC->Detector("EEMC");
+  tower_EEMC->set_sim_tower_node_prefix("SIM");
+  tower_EEMC->GeometryTableFile(mapping_eemc.str());
+
+  se->registerSubsystem(tower_EEMC);
+
+  /* Calorimeter digitization */
+
+  // CMS lead tungstate barrel ECAL at 18 degree centrigrade: 4.5 photoelectrons per MeV
+  const double EEMC_photoelectron_per_GeV = 4500;
+
+  RawTowerDigitizer *TowerDigitizer_EEMC = new RawTowerDigitizer("EEMCRawTowerDigitizer");
+  TowerDigitizer_EEMC->Detector("EEMC");
+  TowerDigitizer_EEMC->Verbosity(verbosity);
+  TowerDigitizer_EEMC->set_raw_tower_node_prefix("RAW");
+  TowerDigitizer_EEMC->set_digi_algorithm(G4EEMC::TowerDigi);
+  TowerDigitizer_EEMC->set_pedstal_central_ADC(0);
+  TowerDigitizer_EEMC->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+  TowerDigitizer_EEMC->set_photonelec_ADC(1);     //not simulating ADC discretization error
+  TowerDigitizer_EEMC->set_photonelec_yield_visible_GeV(EEMC_photoelectron_per_GeV);
+  TowerDigitizer_EEMC->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+
+  se->registerSubsystem(TowerDigitizer_EEMC);
+
+  /* Calorimeter calibration */
+
+  RawTowerCalibration *TowerCalibration_EEMC = new RawTowerCalibration("EEMCRawTowerCalibration");
+  TowerCalibration_EEMC->Detector("EEMC");
+  TowerCalibration_EEMC->Verbosity(verbosity);
+  TowerCalibration_EEMC->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  if (G4EEMC::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    TowerCalibration_EEMC->set_calib_const_GeV_ADC(1.);
+  }
+  else
+  {
+    TowerCalibration_EEMC->set_calib_const_GeV_ADC(1. / EEMC_photoelectron_per_GeV);
+  }
+  TowerCalibration_EEMC->set_pedstal_ADC(0);
+
+  se->registerSubsystem(TowerCalibration_EEMC);
+}
+
+void EEMC_Clusters()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::EEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4EEMC::Eemc_clusterizer == G4EEMC::kEemcTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EEMCRawClusterBuilderTemplate");
+
+    ClusterBuilder->Detector("EEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4EEMC::Eemc_clusterizer == G4EEMC::kEemcGraphClusterizer)
+  {
+    RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("EEMCRawClusterBuilderFwd");
+
+    ClusterBuilder->Detector("EEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "EEMC_Clusters - unknown clusterizer setting " << G4EEMC::Eemc_clusterizer << endl;
+    gSystem->Exit(1);
+  }
+  return;
+}
+
+void EEMC_Eval(const std::string &outputfile)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::EEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  CaloEvaluator *eval = new CaloEvaluator("EEMCEVALUATOR", "EEMC", outputfile.c_str());
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+
+  return;
+}
+#endif

--- a/common/G4_FEMC.C
+++ b/common/G4_FEMC.C
@@ -1,0 +1,261 @@
+#ifndef MACRO_G4FEMC_C
+#define MACRO_G4FEMC_C
+
+#include <GlobalVariables.C>
+
+#include <g4calo/RawTowerBuilderByHitIndex.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <g4detectors/PHG4ForwardEcalSubsystem.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+
+namespace Enable
+{
+  bool FEMC = false;
+  bool FEMC_ABSORBER = false;
+  bool FEMC_CELL = false;
+  bool FEMC_TOWER = false;
+  bool FEMC_CLUSTER = false;
+  bool FEMC_EVAL = false;
+  bool FEMC_OVERLAPCHECK = false;
+  int FEMC_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4FEMC
+{
+  // from ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt
+  double Gz0 = 305.;
+  double Gdz = 40.;
+  double outer_radius = 180.;
+  string calibfile = "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  enum enu_Femc_clusterizer
+  {
+    kFemcGraphClusterizer,
+    kFemcTemplateClusterizer
+  };
+
+  //template clusterizer, as developed by Sasha Bazilevsky
+  enu_Femc_clusterizer Femc_clusterizer = kFemcTemplateClusterizer;
+  // graph clusterizer
+  //enu_Femc_clusterizer Femc_clusterizer = kFemcGraphClusterizer;
+}  // namespace G4FEMC
+
+void FEMCInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FEMC::outer_radius);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FEMC::Gz0 + G4FEMC::Gdz / 2.);
+}
+
+void FEMCSetup(PHG4Reco *g4Reco, const int absorberactive = 0)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::FEMC_ABSORBER || (absorberactive > 0);
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FEMC_OVERLAPCHECK;
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  /** Use dedicated FEMC module */
+  PHG4ForwardEcalSubsystem *femc = new PHG4ForwardEcalSubsystem("FEMC");
+
+  ostringstream mapping_femc;
+
+  // fsPHENIX ECAL
+  femc->SetfsPHENIXDetector();
+  mapping_femc << getenv("CALIBRATIONROOT") << G4FEMC::calibfile;
+
+  //  cout << mapping_femc.str() << endl;
+  femc->SetTowerMappingFile(mapping_femc.str());
+  femc->OverlapCheck(OverlapCheck);
+  femc->SetActive();
+  femc->SuperDetector("FEMC");
+  if (AbsorberActive) femc->SetAbsorberActive(AbsorberActive);
+
+  g4Reco->registerSubsystem(femc);
+}
+
+void FEMC_Cells()
+{
+  return;
+}
+
+void FEMC_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FEMC_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  ostringstream mapping_femc;
+
+  // fsPHENIX ECAL
+  mapping_femc << getenv("CALIBRATIONROOT") << G4FEMC::calibfile;
+
+  RawTowerBuilderByHitIndex *tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
+  tower_FEMC->Detector("FEMC");
+  tower_FEMC->set_sim_tower_node_prefix("SIM");
+  tower_FEMC->GeometryTableFile(mapping_femc.str());
+
+  se->registerSubsystem(tower_FEMC);
+
+  // PbW crystals
+  //RawTowerDigitizer *TowerDigitizer1 = new RawTowerDigitizer("FEMCRawTowerDigitizer1");
+  //TowerDigitizer1->Detector("FEMC");
+  //TowerDigitizer1->TowerType(1);
+  //TowerDigitizer1->Verbosity(verbosity);
+  //TowerDigitizer1->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  //se->registerSubsystem( TowerDigitizer1 );
+
+  // PbSc towers
+  //RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
+  //TowerDigitizer2->Detector("FEMC");
+  //TowerDigitizer2->TowerType(2);
+  //TowerDigitizer2->Verbosity(verbosity);
+  //TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  //se->registerSubsystem( TowerDigitizer2 );
+
+  // E864 towers (three types for three sizes)
+  RawTowerDigitizer *TowerDigitizer3 = new RawTowerDigitizer("FEMCRawTowerDigitizer3");
+  TowerDigitizer3->Detector("FEMC");
+  TowerDigitizer3->TowerType(3);
+  TowerDigitizer3->Verbosity(verbosity);
+  TowerDigitizer3->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  se->registerSubsystem(TowerDigitizer3);
+
+  RawTowerDigitizer *TowerDigitizer4 = new RawTowerDigitizer("FEMCRawTowerDigitizer4");
+  TowerDigitizer4->Detector("FEMC");
+  TowerDigitizer4->TowerType(4);
+  TowerDigitizer4->Verbosity(verbosity);
+  TowerDigitizer4->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  se->registerSubsystem(TowerDigitizer4);
+
+  RawTowerDigitizer *TowerDigitizer5 = new RawTowerDigitizer("FEMCRawTowerDigitizer5");
+  TowerDigitizer5->Detector("FEMC");
+  TowerDigitizer5->TowerType(5);
+  TowerDigitizer5->Verbosity(verbosity);
+  TowerDigitizer5->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  se->registerSubsystem(TowerDigitizer5);
+
+  RawTowerDigitizer *TowerDigitizer6 = new RawTowerDigitizer("FEMCRawTowerDigitizer6");
+  TowerDigitizer6->Detector("FEMC");
+  TowerDigitizer6->TowerType(6);
+  TowerDigitizer6->Verbosity(verbosity);
+  TowerDigitizer6->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  se->registerSubsystem(TowerDigitizer6);
+
+  // PbW crystals
+  //RawTowerCalibration *TowerCalibration1 = new RawTowerCalibration("FEMCRawTowerCalibration1");
+  //TowerCalibration1->Detector("FEMC");
+  //TowerCalibration1->TowerType(1);
+  //TowerCalibration1->Verbosity(verbosity);
+  //TowerCalibration1->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  //TowerCalibration1->set_calib_const_GeV_ADC(1.0);  // sampling fraction = 1.0
+  //TowerCalibration1->set_pedstal_ADC(0);
+  //se->registerSubsystem( TowerCalibration1 );
+
+  // PbSc towers
+  //RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
+  //TowerCalibration2->Detector("FEMC");
+  //TowerCalibration2->TowerType(2);
+  //TowerCalibration2->Verbosity(verbosity);
+  //TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  //TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.249);  // sampling fraction = 0.249 for e-
+  //TowerCalibration2->set_pedstal_ADC(0);
+  //se->registerSubsystem( TowerCalibration2 );
+
+  // E864 towers (three types for three sizes)
+  RawTowerCalibration *TowerCalibration3 = new RawTowerCalibration("FEMCRawTowerCalibration3");
+  TowerCalibration3->Detector("FEMC");
+  TowerCalibration3->TowerType(3);
+  TowerCalibration3->Verbosity(verbosity);
+  TowerCalibration3->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration3->set_calib_const_GeV_ADC(1.0 / 0.030);  // sampling fraction = 0.030
+  TowerCalibration3->set_pedstal_ADC(0);
+  se->registerSubsystem(TowerCalibration3);
+
+  RawTowerCalibration *TowerCalibration4 = new RawTowerCalibration("FEMCRawTowerCalibration4");
+  TowerCalibration4->Detector("FEMC");
+  TowerCalibration4->TowerType(4);
+  TowerCalibration4->Verbosity(verbosity);
+  TowerCalibration4->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration4->set_calib_const_GeV_ADC(1.0 / 0.030);  // sampling fraction = 0.030
+  TowerCalibration4->set_pedstal_ADC(0);
+  se->registerSubsystem(TowerCalibration4);
+
+  RawTowerCalibration *TowerCalibration5 = new RawTowerCalibration("FEMCRawTowerCalibration5");
+  TowerCalibration5->Detector("FEMC");
+  TowerCalibration5->TowerType(5);
+  TowerCalibration5->Verbosity(verbosity);
+  TowerCalibration5->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration5->set_calib_const_GeV_ADC(1.0 / 0.030);  // sampling fraction = 0.030
+  TowerCalibration5->set_pedstal_ADC(0);
+  se->registerSubsystem(TowerCalibration5);
+
+  RawTowerCalibration *TowerCalibration6 = new RawTowerCalibration("FEMCRawTowerCalibration6");
+  TowerCalibration6->Detector("FEMC");
+  TowerCalibration6->TowerType(6);
+  TowerCalibration6->Verbosity(verbosity);
+  TowerCalibration6->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration6->set_calib_const_GeV_ADC(1.0 / 0.030);  // sampling fraction = 0.030
+  TowerCalibration6->set_pedstal_ADC(0);
+  se->registerSubsystem(TowerCalibration6);
+}
+
+void FEMC_Clusters()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4FEMC::Femc_clusterizer == G4FEMC::kFemcTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplateFEMC");
+    ClusterBuilder->Detector("FEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.020);  // This threshold should be the same as in FEMCprof_Thresh**.root file below
+    std::string femc_prof = getenv("CALIBRATIONROOT");
+    femc_prof += "/EmcProfile/FEMCprof_Thresh20MeV.root";
+    ClusterBuilder->LoadProfile(femc_prof.c_str());
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4FEMC::Femc_clusterizer == G4FEMC::kFemcGraphClusterizer)
+  {
+    RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("FEMCRawClusterBuilderFwd");
+
+    ClusterBuilder->Detector("FEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.010);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "FEMC_Clusters - unknown clusterizer setting!" << endl;
+    exit(1);
+  }
+
+  return;
+}
+
+void FEMC_Eval(std::string outputfile)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FEMC_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  CaloEvaluator *eval = new CaloEvaluator("FEMCEVALUATOR", "FEMC", outputfile.c_str());
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+
+  return;
+}
+#endif

--- a/common/G4_FEMC_EIC.C
+++ b/common/G4_FEMC_EIC.C
@@ -1,0 +1,312 @@
+#ifndef MACRO_G4FEMCEIC_C
+#define MACRO_G4FEMCEIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4calo/RawTowerBuilderByHitIndex.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <g4detectors/PHG4ForwardEcalSubsystem.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+
+namespace Enable
+{
+  bool FEMC = false;
+  bool FEMC_ABSORBER = false;
+  bool FEMC_CELL = false;
+  bool FEMC_TOWER = false;
+  bool FEMC_CLUSTER = false;
+  bool FEMC_EVAL = false;
+  bool FEMC_OVERLAPCHECK = false;
+  int FEMC_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4FEMC
+{
+  // from ForwardEcal/mapping/towerMap_FEMC_v007.txt
+  const double Gz0 = 310.;
+  const double Gdz = 36.5;
+  const double outer_radius = 182.655;
+  enum enu_Femc_clusterizer
+  {
+    kFemcGraphClusterizer,
+    kFemcTemplateClusterizer
+  };
+  //template clusterizer, as developed by Sasha Bazilevsky
+  enu_Femc_clusterizer Femc_clusterizer = kFemcTemplateClusterizer;
+  // graph clusterizer
+  //enu_Femc_clusterizer Femc_clusterizer = kFemcGraphClusterizer;
+  namespace SETTING
+  {
+    bool FullEtaAcc = false;
+    bool fsPHENIX = false;
+    bool EC2x = false;
+  }  // namespace SETTING
+}  // namespace G4FEMC
+
+void FEMCInit()
+{
+  // simple way to check if only 1 of the settings is true
+  if ((G4FEMC::SETTING::FullEtaAcc ? 1 : 0) + (G4FEMC::SETTING::fsPHENIX ? 1 : 0) > 1)
+  {
+    cout << "use only  G4FHCAL::SETTING::FullEtaAcc=true or G4FHCAL::SETTING::fsPHENIX=true" << endl;
+    gSystem->Exit(1);
+  }
+
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FEMC::outer_radius);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FEMC::Gz0 + G4FEMC::Gdz / 2.);
+}
+
+void FEMCSetup(PHG4Reco *g4Reco)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::FEMC_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FEMC_OVERLAPCHECK;
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  /** Use dedicated FEMC module */
+  PHG4ForwardEcalSubsystem *femc = new PHG4ForwardEcalSubsystem("FEMC");
+
+  ostringstream mapping_femc;
+
+  // PbScint ECAL with nominal eta coverage
+  if (G4FEMC::SETTING::FullEtaAcc)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fullEtaCov.txt";
+  }
+  // doubled granularity ECAL
+  else if (G4FEMC::SETTING::EC2x)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_2x.txt";
+  }
+  // fsPHENIX ECAL
+  else if (G4FEMC::SETTING::fsPHENIX)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  }
+  // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
+  }
+  cout << mapping_femc.str() << endl;
+  femc->SetTowerMappingFile(mapping_femc.str());
+  femc->OverlapCheck(OverlapCheck);
+  femc->SetActive();
+  femc->SuperDetector("FEMC");
+  if (AbsorberActive) femc->SetAbsorberActive();
+
+  g4Reco->registerSubsystem(femc);
+}
+
+void FEMC_Cells()
+{
+  return;
+}
+
+void FEMC_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  ostringstream mapping_femc;
+
+  //  // fsPHENIX ECAL
+  //  mapping_femc << getenv("CALIBRATIONROOT") <<
+  //   	"/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
+  // PbScint ECAL with nominal eta coverage
+  if (G4FEMC::SETTING::FullEtaAcc)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fullEtaCov.txt";
+  }
+  // doubled granularity ECAL
+  else if (G4FEMC::SETTING::EC2x)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_2x.txt";
+  }
+  // fsPHENIX ECAL
+  else if (G4FEMC::SETTING::fsPHENIX)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  }
+  // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
+  }
+
+  RawTowerBuilderByHitIndex *tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
+  tower_FEMC->Detector("FEMC");
+  tower_FEMC->set_sim_tower_node_prefix("SIM");
+  tower_FEMC->GeometryTableFile(mapping_femc.str());
+
+  se->registerSubsystem(tower_FEMC);
+
+  // PbW crystals
+  //RawTowerDigitizer *TowerDigitizer1 = new RawTowerDigitizer("FEMCRawTowerDigitizer1");
+  //TowerDigitizer1->Detector("FEMC");
+  //TowerDigitizer1->TowerType(1);
+  //TowerDigitizer1->Verbosity(verbosity);
+  //TowerDigitizer1->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  //se->registerSubsystem( TowerDigitizer1 );
+
+  // PbSc towers
+  RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
+  TowerDigitizer2->Detector("FEMC");
+  TowerDigitizer2->TowerType(2);
+  TowerDigitizer2->Verbosity(verbosity);
+  TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  se->registerSubsystem(TowerDigitizer2);
+
+  //  // E864 towers (three types for three sizes)
+  //  RawTowerDigitizer *TowerDigitizer3 = new RawTowerDigitizer("FEMCRawTowerDigitizer3");
+  //  TowerDigitizer3->Detector("FEMC");
+  //  TowerDigitizer3->TowerType(3);
+  //  TowerDigitizer3->Verbosity(verbosity);
+  //  TowerDigitizer3->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  //  se->registerSubsystem( TowerDigitizer3 );
+  //
+  //  RawTowerDigitizer *TowerDigitizer4 = new RawTowerDigitizer("FEMCRawTowerDigitizer4");
+  //  TowerDigitizer4->Detector("FEMC");
+  //  TowerDigitizer4->TowerType(4);
+  //  TowerDigitizer4->Verbosity(verbosity);
+  //  TowerDigitizer4->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  //  se->registerSubsystem( TowerDigitizer4 );
+  //
+  //  RawTowerDigitizer *TowerDigitizer5 = new RawTowerDigitizer("FEMCRawTowerDigitizer5");
+  //  TowerDigitizer5->Detector("FEMC");
+  //  TowerDigitizer5->TowerType(5);
+  //  TowerDigitizer5->Verbosity(verbosity);
+  //  TowerDigitizer5->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  //  se->registerSubsystem( TowerDigitizer5 );
+  //
+  //  RawTowerDigitizer *TowerDigitizer6 = new RawTowerDigitizer("FEMCRawTowerDigitizer6");
+  //  TowerDigitizer6->Detector("FEMC");
+  //  TowerDigitizer6->TowerType(6);
+  //  TowerDigitizer6->Verbosity(verbosity);
+  //  TowerDigitizer6->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  //  se->registerSubsystem( TowerDigitizer6 );
+
+  // PbW crystals
+  //RawTowerCalibration *TowerCalibration1 = new RawTowerCalibration("FEMCRawTowerCalibration1");
+  //TowerCalibration1->Detector("FEMC");
+  //TowerCalibration1->TowerType(1);
+  //TowerCalibration1->Verbosity(verbosity);
+  //TowerCalibration1->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  //TowerCalibration1->set_calib_const_GeV_ADC(1.0);  // sampling fraction = 1.0
+  //TowerCalibration1->set_pedstal_ADC(0);
+  //se->registerSubsystem( TowerCalibration1 );
+
+  // PbSc towers
+  RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
+  TowerCalibration2->Detector("FEMC");
+  TowerCalibration2->TowerType(2);
+  TowerCalibration2->Verbosity(verbosity);
+  TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration2->set_calib_const_GeV_ADC(1.0 / 0.249);  // sampling fraction = 0.249 for e-
+  TowerCalibration2->set_pedstal_ADC(0);
+  se->registerSubsystem(TowerCalibration2);
+
+  //  // E864 towers (three types for three sizes)
+  //  RawTowerCalibration *TowerCalibration3 = new RawTowerCalibration("FEMCRawTowerCalibration3");
+  //  TowerCalibration3->Detector("FEMC");
+  //  TowerCalibration3->TowerType(3);
+  //  TowerCalibration3->Verbosity(verbosity);
+  //  TowerCalibration3->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  //  TowerCalibration3->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+  //  TowerCalibration3->set_pedstal_ADC(0);
+  //  se->registerSubsystem( TowerCalibration3 );
+  //
+  //  RawTowerCalibration *TowerCalibration4 = new RawTowerCalibration("FEMCRawTowerCalibration4");
+  //  TowerCalibration4->Detector("FEMC");
+  //  TowerCalibration4->TowerType(4);
+  //  TowerCalibration4->Verbosity(verbosity);
+  //  TowerCalibration4->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  //  TowerCalibration4->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+  //  TowerCalibration4->set_pedstal_ADC(0);
+  //  se->registerSubsystem( TowerCalibration4 );
+  //
+  //  RawTowerCalibration *TowerCalibration5 = new RawTowerCalibration("FEMCRawTowerCalibration5");
+  //  TowerCalibration5->Detector("FEMC");
+  //  TowerCalibration5->TowerType(5);
+  //  TowerCalibration5->Verbosity(verbosity);
+  //  TowerCalibration5->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  //  TowerCalibration5->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+  //  TowerCalibration5->set_pedstal_ADC(0);
+  //  se->registerSubsystem( TowerCalibration5 );
+  //
+  //  RawTowerCalibration *TowerCalibration6 = new RawTowerCalibration("FEMCRawTowerCalibration6");
+  //  TowerCalibration6->Detector("FEMC");
+  //  TowerCalibration6->TowerType(6);
+  //  TowerCalibration6->Verbosity(verbosity);
+  //  TowerCalibration6->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  //  TowerCalibration6->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+  //  TowerCalibration6->set_pedstal_ADC(0);
+  //  se->registerSubsystem( TowerCalibration6 );
+}
+
+void FEMC_Clusters()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4FEMC::Femc_clusterizer == G4FEMC::kFemcTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplateFEMC");
+    ClusterBuilder->Detector("FEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.020);  // This threshold should be the same as in FEMCprof_Thresh**.root file below
+    std::string femc_prof = getenv("CALIBRATIONROOT");
+    femc_prof += "/EmcProfile/FEMCprof_Thresh20MeV.root";
+    ClusterBuilder->LoadProfile(femc_prof.c_str());
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4FEMC::Femc_clusterizer == G4FEMC::kFemcGraphClusterizer)
+  {
+    RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("FEMCRawClusterBuilderFwd");
+
+    ClusterBuilder->Detector("FEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.010);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "FEMC_Clusters - unknown clusterizer setting!" << endl;
+    exit(1);
+  }
+
+  return;
+}
+
+void FEMC_Eval(const std::string &outputfile)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  CaloEvaluator *eval = new CaloEvaluator("FEMCEVALUATOR", "FEMC", outputfile);
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+
+  return;
+}
+#endif

--- a/common/G4_FGEM_fsPHENIX.C
+++ b/common/G4_FGEM_fsPHENIX.C
@@ -1,0 +1,354 @@
+#ifndef MACRO_G4FGEMFSPHENIX_C
+#define MACRO_G4FGEMFSPHENIX_C
+
+#include <GlobalVariables.C>
+
+#include <G4_FEMC.C>
+#include <G4_FHCAL.C>
+
+#include <g4detectors/PHG4SectorSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <g4trackfastsim/PHG4TrackFastSim.h>
+#include <g4trackfastsim/PHG4TrackFastSimEval.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libg4trackfastsim.so)
+
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8);
+void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
+
+namespace Enable
+{
+  bool FGEM = false;
+  bool FGEM_OVERLAPCHECK = false;
+  bool FGEM_TRACK = false;
+  bool FGEM_EVAL = false;
+  int FGEM_VERBOSITY = 0;
+}  // namespace Enable
+
+void FGEM_Init()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 130.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 280.);
+  TRACKING::TrackNodeName = "SvtxTrackMap";  // node name for tracks
+}
+
+void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
+               const double min_eta = 1.45                //
+)
+{
+  const double tilt = .1;
+
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FGEM_OVERLAPCHECK;
+
+  string name;
+  double etamax;
+  double etamin;
+  double zpos;
+  PHG4SectorSubsystem *gem;
+
+  make_GEM_station("FGEM_0", g4Reco, 17, 1.01, 2.7, N_Sector);
+  make_GEM_station("FGEM_1", g4Reco, 62, 2.15, 4.0, N_Sector);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  name = "FGEM_2";
+  etamax = 4;
+  etamin = min_eta;
+  zpos = 1.2e2;
+
+  gem = new PHG4SectorSubsystem(name);
+
+  gem->get_geometry().set_normal_polar_angle(tilt);
+  gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+  gem->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->OverlapCheck(OverlapCheck);
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  name = "FGEM_3";
+  etamax = 4;
+  etamin = min_eta;
+  zpos = 1.6e2;
+  gem = new PHG4SectorSubsystem(name);
+
+  gem->SuperDetector(name);
+  gem->get_geometry().set_normal_polar_angle(tilt);
+  gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->OverlapCheck(OverlapCheck);
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
+
+  gem = new PHG4SectorSubsystem(name + "_LowerEta");
+  gem->SuperDetector(name);
+
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt)) * sin(tilt);
+
+  gem->get_geometry().set_normal_polar_angle((PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+  gem->get_geometry().set_normal_start(
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  gem->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(gem);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  name = "FGEM_4";
+  etamax = 4;
+  etamin = min_eta;
+  zpos = 2.75e2;
+  gem = new PHG4SectorSubsystem(name);
+
+  gem->SuperDetector(name);
+  gem->get_geometry().set_normal_polar_angle(tilt);
+  gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->OverlapCheck(OverlapCheck);
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
+
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt)) * sin(tilt);
+
+  gem = new PHG4SectorSubsystem(name + "_LowerEta");
+  gem->SuperDetector(name);
+
+  gem->get_geometry().set_normal_polar_angle((PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+  gem->get_geometry().set_normal_start(
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  gem->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(gem);
+
+  ///////////////////////////////////////////////////////////////////////////
+}
+
+//! Add drift layers to mini TPC
+void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
+{
+  assert(gem);
+
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
+
+  //  const int N_Layers = 70; // used for mini-drift TPC timing digitalization
+  const int N_Layers = 1;  // simplified setup
+  const double thickness = 2 * cm;
+
+  gem->get_geometry().AddLayer("EntranceWindow", "G4_MYLAR", 25 * um, false, 100);
+  gem->get_geometry().AddLayer("Cathode", "G4_GRAPHITE", 10 * um, false, 100);
+
+  for (int d = 1; d <= N_Layers; d++)
+  {
+    stringstream s;
+    s << "DriftLayer_";
+    s << d;
+
+    gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers, true);
+  }
+}
+
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8)
+{
+  //  cout
+  //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+  //      << name << endl;
+
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FGEM_OVERLAPCHECK;
+
+  double polar_angle = 0;
+
+  if (zpos < 0)
+  {
+    zpos = -zpos;
+    polar_angle = TMath::Pi();
+  }
+  if (etamax < etamin)
+  {
+    double t = etamax;
+    etamax = etamin;
+    etamin = t;
+  }
+
+  PHG4SectorSubsystem *gem;
+  gem = new PHG4SectorSubsystem(name);
+
+  gem->SuperDetector(name);
+
+  gem->get_geometry().set_normal_polar_angle(polar_angle);
+  gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm());
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+  gem->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->OverlapCheck(OverlapCheck);
+
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
+  return 0;
+}
+
+void FGEM_FastSim_Reco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FGEM_VERBOSITY);
+
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4TrackFastSim *kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
+  kalman->Verbosity(verbosity);
+
+  kalman->set_use_vertex_in_fitting(true);
+  kalman->set_vertex_xy_resolution(50E-4);
+  kalman->set_vertex_z_resolution(50E-4);
+
+  kalman->set_sub_top_node_name("SVTX");
+  kalman->set_trackmap_out_name(TRACKING::TrackNodeName);
+
+  //   MAPS in MVTX detector
+  kalman->add_phg4hits(
+      "G4HIT_MVTX",                //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                        //      const float radres,
+      5e-4,                        //      const float phires,
+      5e-4,                        //      const float lonres,
+      1,                           //      const float eff,
+      0                            //      const float noise
+  );
+
+  // GEM0, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_0",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                     //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM1, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_1",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                     //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
+  // TPC
+  kalman->add_phg4hits(
+      "G4HIT_TPC",                 //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+      1,                           //      const float radres,
+      200e-4,                      //      const float phires,
+      500e-4,                      //      const float lonres,
+      1,                           //      const float eff,
+      0                            //      const float noise
+  );
+
+  // GEM2, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_2",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                     //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM3, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_3",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                     //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM4, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_4",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                     //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
+  // Saved track states (projections)
+
+  if (Enable::FEMC)
+  {
+    kalman->add_state_name("FEMC");
+  }
+  if (Enable::FHCAL)
+  {
+    kalman->add_state_name("FHCAL");
+  }
+  se->registerSubsystem(kalman);
+}
+
+void FGEM_FastSim_Eval(const std::string &outputfile)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FGEM_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4TrackFastSimEval *fast_sim_eval = new PHG4TrackFastSimEval("FastTrackingEval");
+  fast_sim_eval->set_trackmapname(TRACKING::TrackNodeName);
+  fast_sim_eval->set_filename(outputfile);
+  se->registerSubsystem(fast_sim_eval);
+
+  return;
+}
+#endif

--- a/common/G4_FHCAL.C
+++ b/common/G4_FHCAL.C
@@ -1,0 +1,352 @@
+#ifndef MACRO_G4FHCAL_C
+#define MACRO_G4FHCAL_C
+
+#include <GlobalVariables.C>
+
+#include <g4calo/RawTowerBuilderByHitIndex.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <g4detectors/PHG4ForwardHcalSubsystem.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+
+namespace Enable
+{
+  bool FHCAL = false;
+  bool FHCAL_ABSORBER = false;
+  bool FHCAL_CELL = false;
+  bool FHCAL_TOWER = false;
+  bool FHCAL_CLUSTER = false;
+  bool FHCAL_EVAL = false;
+  bool FHCAL_OVERLAPCHECK = false;
+  int FHCAL_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4FHCAL
+{
+  // from ForwardHcal/mapping/towerMap_FHCAL_v005.txt
+  double Gz0 = 400.;
+  double Gdz = 100.;
+  double outer_radius = 262.;
+  enum enu_FHcal_clusterizer
+  {
+    kFHcalGraphClusterizer,
+    kFHcalTemplateClusterizer
+  };
+  //template clusterizer, as developed by Sasha Bazilevsky
+  enu_FHcal_clusterizer FHcal_clusterizer = kFHcalTemplateClusterizer;
+  // graph clusterizer
+  //enu_FHcal_clusterizer FHcal_clusterizer = kFHcalGraphClusterizer;
+  namespace SETTING
+  {
+    bool FullEtaAcc = false;
+    bool HC2x = false;
+    bool HC4x = false;
+    bool towercalib1 = false;
+    bool towercalibSiPM = false;
+    bool towercalibHCALIN = false;
+    bool towercalib3 = false;
+  }  // namespace SETTING
+}  // namespace G4FHCAL
+
+void FHCALInit()
+{
+  // simple way to check if only 1 of the settings is true
+  if ((G4FHCAL::SETTING::FullEtaAcc ? 1 : 0) + (G4FHCAL::SETTING::HC4x ? 1 : 0) + (G4FHCAL::SETTING::HC2x ? 1 : 0) > 1)
+  {
+    cout << "use only  G4FHCAL::SETTING::FullEtaAcc=true or G4FHCAL::SETTING::HC2x=true or G4FHCAL::SETTING::HC4x=true" << endl;
+    gSystem->Exit(1);
+  }
+  if ((G4FHCAL::SETTING::towercalib1 ? 1 : 0) + (G4FHCAL::SETTING::towercalibSiPM ? 1 : 0) +
+          (G4FHCAL::SETTING::towercalibHCALIN ? 1 : 0) + (G4FHCAL::SETTING::towercalib3 ? 1 : 0) >
+      1)
+  {
+    cout << "use only G4FHCAL::SETTING::towercalib1 = true or G4FHCAL::SETTING::towercalibSiPM = true"
+         << " or G4FHCAL::SETTING::towercalibHCALIN = true or G4FHCAL::SETTING::towercalib3 = true" << endl;
+    gSystem->Exit(1);
+  }
+
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FHCAL::outer_radius);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FHCAL::Gz0 + G4FHCAL::Gdz / 2.);
+}
+
+void FHCALSetup(PHG4Reco *g4Reco)
+{
+  const bool AbsorberActive = Enable::ABSORBER || Enable::FHCAL_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FHCAL_OVERLAPCHECK;
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  /** Use dedicated FHCAL module */
+  PHG4ForwardHcalSubsystem *fhcal = new PHG4ForwardHcalSubsystem("FHCAL");
+
+  ostringstream mapping_fhcal;
+
+  // Switch to desired calo setup
+  // HCal Fe-Scint with doubled granularity
+  if (G4FHCAL::SETTING::HC2x )
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance doubled granularity
+  else if (G4FHCAL::SETTING::HC2x && G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x_fullEtaCov.txt";
+  }
+  // HCal Fe-Scint with four times granularity
+  else if (G4FHCAL::SETTING::HC4x )
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance four times granularity
+  else if (G4FHCAL::SETTING::HC4x && G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x_fullEtaCov.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance
+  else if (G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_default_fullEtaCov.txt";
+  }
+  // full HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT")
+                  << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
+  }
+
+  fhcal->SetTowerMappingFile(mapping_fhcal.str());
+  fhcal->OverlapCheck(OverlapCheck);
+  fhcal->SetActive();
+  fhcal->SuperDetector("FHCAL");
+  if (AbsorberActive) fhcal->SetAbsorberActive();
+
+  g4Reco->registerSubsystem(fhcal);
+}
+
+void FHCAL_Cells(int verbosity = 0)
+{
+  return;
+}
+
+void FHCAL_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FHCAL_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  ostringstream mapping_fhcal;
+
+  // Switch to desired calo setup
+  // HCal Fe-Scint with doubled granularity
+  if (G4FHCAL::SETTING::HC2x )
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance doubled granularity
+  else if (G4FHCAL::SETTING::HC2x && G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x_fullEtaCov.txt";
+  }
+  // HCal Fe-Scint with four times granularity
+  else if (G4FHCAL::SETTING::HC4x )
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance four times granularity
+  else if (G4FHCAL::SETTING::HC4x && G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x_fullEtaCov.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance
+  else if (G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_default_fullEtaCov.txt";
+  }
+  // full HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
+  }
+
+  RawTowerBuilderByHitIndex *tower_FHCAL = new RawTowerBuilderByHitIndex("TowerBuilder_FHCAL");
+  tower_FHCAL->Detector("FHCAL");
+  tower_FHCAL->set_sim_tower_node_prefix("SIM");
+  tower_FHCAL->GeometryTableFile(mapping_fhcal.str());
+
+  se->registerSubsystem(tower_FHCAL);
+
+  // enable usage of different tower calibrations for systematic studies
+  if (G4FHCAL::SETTING::towercalib1)
+  {
+    cout << "1: using towercalib1 for FHCAL towers" << endl;
+    const double FHCAL_photoelectron_per_GeV = 500;
+    RawTowerDigitizer *TowerDigitizer_FHCAL = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+
+    TowerDigitizer_FHCAL->Detector("FHCAL");
+    TowerDigitizer_FHCAL->Verbosity(verbosity);
+    TowerDigitizer_FHCAL->set_raw_tower_node_prefix("RAW");
+    TowerDigitizer_FHCAL->set_digi_algorithm(RawTowerDigitizer::kSiPM_photon_digitization);
+    TowerDigitizer_FHCAL->set_pedstal_central_ADC(0);
+    TowerDigitizer_FHCAL->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+    TowerDigitizer_FHCAL->set_photonelec_ADC(1);     //not simulating ADC discretization error
+    TowerDigitizer_FHCAL->set_photonelec_yield_visible_GeV(FHCAL_photoelectron_per_GeV);
+    TowerDigitizer_FHCAL->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+
+    se->registerSubsystem(TowerDigitizer_FHCAL);
+
+    RawTowerCalibration *TowerCalibration_FHCAL = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration_FHCAL->Detector("FHCAL");
+    TowerCalibration_FHCAL->Verbosity(verbosity);
+    TowerCalibration_FHCAL->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration_FHCAL->set_calib_const_GeV_ADC(1. / FHCAL_photoelectron_per_GeV);
+    TowerCalibration_FHCAL->set_pedstal_ADC(0);
+
+    se->registerSubsystem(TowerCalibration_FHCAL);
+  }
+  else if (G4FHCAL::SETTING::towercalibSiPM)
+  {
+    //from https://sphenix-collaboration.github.io/doxygen/d4/d58/Fun4All__G4__Prototype4_8C_source.html
+    const double sampling_fraction = 0.019441;     //  +/-  0.019441 from 0 Degree indenting 12 GeV electron showers
+    const double photoelectron_per_GeV = 500;      //500 photon per total GeV deposition
+    const double ADC_per_photoelectron_HG = 3.8;   // From Sean Stoll, Mar 29
+    const double ADC_per_photoelectron_LG = 0.24;  // From Sean Stoll, Mar 29
+
+    cout << "2: using towercalibSiPM for FHCAL towers" << endl;
+    RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer->Detector("FHCAL");
+    TowerDigitizer->set_raw_tower_node_prefix("RAW");
+    TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSiPM_photon_digitization);
+    TowerDigitizer->set_pedstal_central_ADC(0);
+    TowerDigitizer->set_pedstal_width_ADC(1);
+    TowerDigitizer->set_photonelec_ADC(1. / ADC_per_photoelectron_LG);
+    TowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
+    TowerDigitizer->set_zero_suppression_ADC(-1000);  // no-zero suppression
+    se->registerSubsystem(TowerDigitizer);
+
+    RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration->Detector("FHCAL");
+    TowerCalibration->set_raw_tower_node_prefix("RAW");
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration->set_calib_const_GeV_ADC(1. / ADC_per_photoelectron_LG / photoelectron_per_GeV);
+    TowerCalibration->set_pedstal_ADC(0);
+    TowerCalibration->set_zero_suppression_GeV(-1);  // no-zero suppression
+    se->registerSubsystem(TowerCalibration);
+  }
+  else if (G4FHCAL::SETTING::towercalibHCALIN)
+  {
+    const double visible_sample_fraction_HCALIN = 7.19505e-02;  // 1.34152e-02
+    RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer->Detector("FHCAL");
+    TowerDigitizer->set_raw_tower_node_prefix("RAW");
+    TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitalization);
+    TowerDigitizer->set_pedstal_central_ADC(0);
+    TowerDigitizer->set_pedstal_width_ADC(1);
+    TowerDigitizer->set_photonelec_ADC(32. / 5.);
+    TowerDigitizer->set_photonelec_yield_visible_GeV(32. / 5 / (0.4e-3));
+    TowerDigitizer->set_zero_suppression_ADC(-1000);  // no-zero suppression
+    se->registerSubsystem(TowerDigitizer);
+
+    RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration->Detector("FHCAL");
+    TowerCalibration->set_raw_tower_node_prefix("RAW");
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration->set_calib_const_GeV_ADC(0.4e-3 / visible_sample_fraction_HCALIN);
+    TowerCalibration->set_pedstal_ADC(0);
+    TowerCalibration->set_zero_suppression_GeV(-1);  // no-zero suppression
+    se->registerSubsystem(TowerCalibration);
+  }
+  else if (G4FHCAL::SETTING::towercalib3)
+  {
+    cout << "3: using towercalib3 for FHCAL towers" << endl;
+    RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer->Detector("FHCAL");
+    TowerDigitizer->set_pedstal_central_ADC(0);
+    TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+    TowerDigitizer->Verbosity(verbosity);
+    TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+    se->registerSubsystem(TowerDigitizer);
+
+    RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration->Detector("FHCAL");
+    TowerCalibration->Verbosity(verbosity);
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration->set_calib_const_GeV_ADC(1. / 0.03898);  // calibrated with muons
+    TowerCalibration->set_pedstal_ADC(0);
+    se->registerSubsystem(TowerCalibration);
+  }
+  else
+  {
+    cout << "def: using default for FHCAL towers" << endl;
+    RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer->Detector("FHCAL");
+    TowerDigitizer->Verbosity(verbosity);
+    TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+    se->registerSubsystem(TowerDigitizer);
+
+    RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration->Detector("FHCAL");
+    TowerCalibration->Verbosity(verbosity);
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration->set_calib_const_GeV_ADC(1. / 0.03898);  // calibrated with muons
+    TowerCalibration->set_pedstal_ADC(0);
+    se->registerSubsystem(TowerCalibration);
+  }
+}
+
+void FHCAL_Clusters()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FHCAL_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4FHCAL::FHcal_clusterizer == G4FHCAL::kFHcalTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("FHCALRawClusterBuilderTemplate");
+    ClusterBuilder->Detector("FHCAL");
+    ClusterBuilder->SetPlanarGeometry();  // has to be called after Detector()
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.100);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4FHCAL::FHcal_clusterizer == G4FHCAL::kFHcalTemplateClusterizer)
+  {
+    RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("FHCALRawClusterBuilderFwd");
+    ClusterBuilder->Detector("FHCAL");
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.100);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "FHCAL_Clusters - unknown clusterizer setting " << G4FHCAL::FHcal_clusterizer << endl;
+    gSystem->Exit(1);
+  }
+
+  return;
+}
+
+void FHCAL_Eval(const std::string &outputfile)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FHCAL_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  CaloEvaluator *eval = new CaloEvaluator("FHCALEVALUATOR", "FHCAL", outputfile.c_str());
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+
+  return;
+}
+#endif

--- a/common/G4_FST_EIC.C
+++ b/common/G4_FST_EIC.C
@@ -1,0 +1,224 @@
+/*---------------------------------------------------------------------*
+ * Barrel tracker designed by LANL EIC team                            *
+ * See technical notes for details: arXiv:2009.02888                   *
+ * Contact Ping and Xuan @LANL for questions:                          *
+ *   Xuan: xuanli@lanl.gov                                             *
+ *   Ping: cpwong@lanl.gov                                             *
+ *---------------------------------------------------------------------*/
+
+#ifndef MACRO_G4FSTEIC_C
+#define MACRO_G4FSTEIC_C
+
+#include "GlobalVariables.C"
+
+#include <g4detectors/PHG4SectorSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <string>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco, double zpos, double Rmin,
+                          double Rmax, double tSilicon);
+//-----------------------------------------------------------------------------------//
+namespace Enable
+{
+  static bool FST = false;
+  bool FST_OVERLAPCHECK = false;
+}  // namespace Enable
+
+namespace G4FST
+{
+  namespace SETTING
+  {
+    bool FSTV0 = false;
+    bool FSTV1 = false;
+    bool FSTV2 = false;
+    bool FSTV3 = false;
+    bool FSTV41 = false;
+    bool FSTV42 = false;
+    bool FSTV4 = false;
+    bool FSTV5 = false;
+    bool FST_TPC = false;
+  }  // namespace SETTING
+}  // namespace G4FST
+
+//-----------------------------------------------------------------------------------//
+void FST_Init()
+{
+  if ((G4FST::SETTING::FSTV0 ? 1 : 0) +
+          (G4FST::SETTING::FSTV1 ? 1 : 0) +
+          (G4FST::SETTING::FSTV2 ? 1 : 0) +
+          (G4FST::SETTING::FSTV3 ? 1 : 0) +
+          (G4FST::SETTING::FSTV4 ? 1 : 0) +
+          (G4FST::SETTING::FSTV41 ? 1 : 0) +
+          (G4FST::SETTING::FSTV42 ? 1 : 0) +
+          (G4FST::SETTING::FSTV5 ? 1 : 0) +
+          (G4FST::SETTING::FST_TPC ? 1 : 0) >
+      1)
+  {
+    cout << "use only G4FST::SETTING::FSTV0=true ";
+    cout << "or G4FST::SETTING::FSTV1=true ";
+    cout << "or G4FST::SETTING::FSTV2=true ";
+    cout << "or G4FST::SETTING::FSTV3=true ";
+    cout << "or G4FST::SETTING::FSTV4=true ";
+    cout << "or G4FST::SETTING::FSTV41=true ";
+    cout << "or G4FST::SETTING::FSTV42=true ";
+    cout << "or G4FST::SETTING::FSTV5=true ";
+    cout << "or G4FST::SETTING::FST_TPC=true " << endl;
+    gSystem->Exit(1);
+  }
+
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 45.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 282.);
+}
+//-----------------------------------------------------------------------------------//
+void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245)
+{
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
+
+  //Design from Xuan Li @LANL
+  // Different FST version documented in arXiv:2009.0288
+  if (G4FST::SETTING::FSTV1)
+  {                                                              // version 1
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 50 * um);
+  }
+  else if (G4FST::SETTING::FSTV2)
+  {                                                              // version 2
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 30, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 35, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 270, 6.5, 45, 50 * um);
+  }
+  else if (G4FST::SETTING::FSTV3)
+  {                                                              // version 3
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+  }
+  else if (G4FST::SETTING::FSTV41)
+  {                                                              // version 4.1
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 100 * um);
+  }
+  else if (G4FST::SETTING::FSTV42)
+  {                                                              // version 4.2
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 100 * um);
+  }
+  else if (G4FST::SETTING::FSTV4)
+  {                                                              // version 4
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 50 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 50 * um);
+  }
+  else if (G4FST::SETTING::FSTV5)
+  {
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 35 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 62.3, 4.5, 42, 35 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 90, 6.5, 43, 35 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 115, 8.9, 44, 85 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 9.5, 45, 85 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 300, 16.8, 45, 85 * um);  //optional disk at further location
+  }
+  else if (G4FST::SETTING::FST_TPC)
+  {                                                              // tpc version (based on version 4)
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 17, 35 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 17, 35 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 17, 35 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 7.5, 17, 85 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 9.5, 45, 85 * um);
+    //make_LANL_FST_station("FST_5", g4Reco, 280, 16, 45, 50 * um);  //optional disk at further location
+  }
+  else
+  {                                                               // Version 0
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 30, 100 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 35, 100 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 100 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+  }
+}
+//-----------------------------------------------------------------------------------//
+int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco,
+                          double zpos, double Rmin, double Rmax, double tSilicon)  //silicon thickness
+{
+  const bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FST_OVERLAPCHECK;
+  //  cout
+  //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+  //      << name << endl;
+
+  // always facing the interaction point
+  double polar_angle = 0;
+  if (zpos < 0)
+  {
+    zpos = -zpos;
+    polar_angle = M_PI;
+  }
+
+  double min_polar_angle = atan2(Rmin, zpos);
+  double max_polar_angle = atan2(Rmax, zpos);
+
+  if (max_polar_angle < min_polar_angle)
+  {
+    double t = max_polar_angle;
+    max_polar_angle = min_polar_angle;
+    min_polar_angle = t;
+  }
+
+  PHG4SectorSubsystem *fst;
+  fst = new PHG4SectorSubsystem(name);
+
+  fst->SuperDetector(name);
+
+  fst->get_geometry().set_normal_polar_angle(polar_angle);
+  fst->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm());
+  fst->get_geometry().set_min_polar_angle(min_polar_angle);
+  fst->get_geometry().set_max_polar_angle(max_polar_angle);
+  fst->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::ConeEdge());
+  fst->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::ConeEdge());
+  fst->get_geometry().set_N_Sector(1);
+  fst->get_geometry().set_material("G4_AIR");
+  fst->OverlapCheck(OverlapCheck);
+
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
+  // build up layers
+
+  fst->get_geometry().AddLayer("SiliconSensor", "G4_Si", tSilicon, true, 100);
+  fst->get_geometry().AddLayer("Metalconnection", "G4_Al", 15 * um, false, 100);
+  fst->get_geometry().AddLayer("HDI", "G4_KAPTON", 20 * um, false, 100);
+  fst->get_geometry().AddLayer("Cooling", "G4_WATER", 100 * um, false, 100);
+  fst->get_geometry().AddLayer("Support", "G4_GRAPHITE", 50 * um, false, 100);
+  fst->get_geometry().AddLayer("Support_Gap", "G4_AIR", 1 * cm, false, 100);
+  fst->get_geometry().AddLayer("Support2", "G4_GRAPHITE", 50 * um, false, 100);
+
+  g4Reco->registerSubsystem(fst);
+  return 0;
+}
+
+#endif
+
+//-----------------------------------------------------------------------------------//

--- a/common/G4_FwdJets.C
+++ b/common/G4_FwdJets.C
@@ -1,0 +1,209 @@
+#ifndef MACRO_G4FWDJETS_C
+#define MACRO_G4FWDJETS_C
+
+// #include <GlobalVariables.C>
+
+#include <g4jets/ClusterJetInput.h>
+#include <g4jets/FastJetAlgo.h>
+#include <g4jets/JetReco.h>
+#include <g4jets/TowerJetInput.h>
+#include <g4jets/TruthJetInput.h>
+#include <g4jets/TrackJetInput.h>
+
+#include <g4eval/JetEvaluator.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libg4jets.so)
+R__LOAD_LIBRARY(libg4eval.so)
+
+namespace Enable
+{
+  bool FWDJETS = false;
+  bool FWDJETS_EVAL = false;
+  int FWDJETS_VERBOSITY = 0;
+}  // namespace Enable
+
+void Jet_FwdRecoInit() {}
+
+void Jet_FwdReco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FWDJETS_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  // truth particle level jets
+  JetReco *truthjetreco = new JetReco("TRUTHJETRECO");
+  truthjetreco->add_input(new TruthJetInput(Jet::PARTICLE));
+  truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Truth_r05");
+  truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Truth_r07");
+  truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_Truth_r10");
+  truthjetreco->set_algo_node("ANTIKT");
+  truthjetreco->set_input_node("TRUTH");
+  truthjetreco->Verbosity(verbosity);
+  se->registerSubsystem(truthjetreco);
+
+  // tower jets
+  JetReco *towerjetreco = new JetReco("TOWERJETRECO");
+  towerjetreco->add_input(new TowerJetInput(Jet::FEMC_TOWER));
+  towerjetreco->add_input(new TowerJetInput(Jet::FHCAL_TOWER));
+  towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWER));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWER));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWER));
+  towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Tower_r05");
+  towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Tower_r07");
+  towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_Tower_r10");
+  towerjetreco->set_algo_node("ANTIKT");
+  towerjetreco->set_input_node("TOWER");
+  towerjetreco->Verbosity(verbosity);
+  se->registerSubsystem(towerjetreco);
+
+  // cluster jets
+  JetReco *clusterjetreco = new JetReco("CLUSTERJETRECO");
+  clusterjetreco->add_input(new ClusterJetInput(Jet::FEMC_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::FHCAL_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::HCALOUT_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::CEMC_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::HCALIN_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::HCALOUT_CLUSTER));
+  clusterjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Cluster_r05");
+  clusterjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Cluster_r07");
+  clusterjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_Cluster_r10");
+  clusterjetreco->set_algo_node("ANTIKT");
+  clusterjetreco->set_input_node("CLUSTER");
+  clusterjetreco->Verbosity(verbosity);
+  se->registerSubsystem(clusterjetreco);
+
+  // tower jets
+  JetReco *towerjetrecofwd = new JetReco("TOWERJETRECOFWD");
+  towerjetrecofwd->add_input(new TowerJetInput(Jet::FEMC_TOWER));
+  towerjetrecofwd->add_input(new TowerJetInput(Jet::FHCAL_TOWER));
+  towerjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_TowerFwd_r05");
+  towerjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_TowerFwd_r07");
+  towerjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_TowerFwd_r10");
+  towerjetrecofwd->set_algo_node("ANTIKT");
+  towerjetrecofwd->set_input_node("TOWER");
+  towerjetrecofwd->Verbosity(verbosity);
+  se->registerSubsystem(towerjetrecofwd);
+
+  // cluster jets
+  JetReco *clusterjetrecofwd = new JetReco("CLUSTERJETRECOFWD");
+  clusterjetrecofwd->add_input(new ClusterJetInput(Jet::FEMC_CLUSTER));
+  clusterjetrecofwd->add_input(new ClusterJetInput(Jet::FHCAL_CLUSTER));
+  clusterjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_ClusterFwd_r05");
+  clusterjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_ClusterFwd_r07");
+  clusterjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_ClusterFwd_r10");
+  clusterjetrecofwd->set_algo_node("ANTIKT");
+  clusterjetrecofwd->set_input_node("CLUSTER");
+  clusterjetrecofwd->Verbosity(verbosity);
+  se->registerSubsystem(clusterjetrecofwd);
+
+
+  // // track jets
+  JetReco *trackjetreco = new JetReco("TRACKJETRECO");
+  trackjetreco->add_input(new TrackJetInput(Jet::TRACK, TRACKING::TrackNodeName));
+  trackjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Track_r05");
+  trackjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Track_r07");
+  trackjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_Track_r10");
+  trackjetreco->set_algo_node("ANTIKT");
+  trackjetreco->set_input_node("TRACK");
+  trackjetreco->Verbosity(verbosity);
+  se->registerSubsystem(trackjetreco);
+
+  // // track jets
+  JetReco *fulljetreco = new JetReco("FULLJETRECO");
+  fulljetreco->add_input(new TrackJetInput(Jet::TRACK, TRACKING::TrackNodeName));
+  fulljetreco->add_input(new ClusterJetInput(Jet::FEMC_CLUSTER));
+  fulljetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Full_r05");
+  fulljetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Full_r07");
+  fulljetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.8), "AntiKt_Full_r08");
+  fulljetreco->set_algo_node("ANTIKT");
+  fulljetreco->set_input_node("FULL");
+  fulljetreco->Verbosity(verbosity);
+  se->registerSubsystem(fulljetreco);
+
+
+  return;
+}
+
+void Jet_FwdEval(const std::string &outfilename = "g4fwdjets_eval.root")
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::FWDJETS_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  JetEvaluator *evaltrk05 = new JetEvaluator("JETEVALUATORTRACK05","AntiKt_Track_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_track_05_eval.root");
+  evaltrk05->Verbosity(verbosity);
+  se->registerSubsystem(evaltrk05);
+
+  JetEvaluator *evalfull05 = new JetEvaluator("JETEVALUATORFULL05","AntiKt_Full_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_full_05_eval.root");
+  evalfull05->Verbosity(verbosity);
+  se->registerSubsystem(evalfull05);
+
+  JetEvaluator *evalt05 = new JetEvaluator("JETEVALUATORTOWER05","AntiKt_Tower_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_tower_05_eval.root");
+  evalt05->Verbosity(verbosity);
+  se->registerSubsystem(evalt05);
+  JetEvaluator *evalt07 = new JetEvaluator("JETEVALUATORTOWER07","AntiKt_Tower_r07",
+                                        "AntiKt_Truth_r07", "g4fwdjets_tower_07_eval.root");
+  evalt07->Verbosity(verbosity);
+  se->registerSubsystem(evalt07);
+  JetEvaluator *evalt10 = new JetEvaluator("JETEVALUATORTOWER10","AntiKt_Tower_r10",
+                                        "AntiKt_Truth_r10", "g4fwdjets_tower_10_eval.root");
+  evalt10->Verbosity(verbosity);
+  se->registerSubsystem(evalt10);
+
+  JetEvaluator *evalc05 = new JetEvaluator("JETEVALUATORCLUSTER05", "AntiKt_Cluster_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_cluster_05_eval.root");
+  evalc05->Verbosity(verbosity);
+  se->registerSubsystem(evalc05);
+
+  JetEvaluator *evalc07 = new JetEvaluator("JETEVALUATORCLUSTER07", "AntiKt_Cluster_r07",
+                                        "AntiKt_Truth_r07", "g4fwdjets_cluster_07_eval.root");
+  evalc07->Verbosity(verbosity);
+  se->registerSubsystem(evalc07);
+
+  JetEvaluator *evalc10 = new JetEvaluator("JETEVALUATORCLUSTER10", "AntiKt_Cluster_r10",
+                                        "AntiKt_Truth_r10", "g4fwdjets_cluster_10_eval.root");
+  evalc10->Verbosity(verbosity);
+  se->registerSubsystem(evalc10);
+
+  JetEvaluator *evaltfwd05 = new JetEvaluator("JETEVALUATORFWDTOWER05","AntiKt_TowerFwd_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_TowerFwd_05_eval.root");
+  evaltfwd05->Verbosity(verbosity);
+  se->registerSubsystem(evaltfwd05);
+  JetEvaluator *evaltfwd07 = new JetEvaluator("JETEVALUATORFWDTOWER07","AntiKt_TowerFwd_r07",
+                                        "AntiKt_Truth_r07", "g4fwdjets_TowerFwd_07_eval.root");
+  evaltfwd07->Verbosity(verbosity);
+  se->registerSubsystem(evaltfwd07);
+  JetEvaluator *evaltfwd10 = new JetEvaluator("JETEVALUATORFWDTOWER10","AntiKt_TowerFwd_r10",
+                                        "AntiKt_Truth_r10", "g4fwdjets_TowerFwd_10_eval.root");
+  evaltfwd10->Verbosity(verbosity);
+  se->registerSubsystem(evaltfwd10);
+
+  JetEvaluator *evalcfwd05 = new JetEvaluator("JETEVALUATORFWDCLUSTER05", "AntiKt_ClusterFwd_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_ClusterFwd_05_eval.root");
+  evalcfwd05->Verbosity(verbosity);
+  se->registerSubsystem(evalcfwd05);
+
+  JetEvaluator *evalcfwd07 = new JetEvaluator("JETEVALUATORFWDCLUSTER07", "AntiKt_ClusterFwd_r07",
+                                        "AntiKt_Truth_r07", "g4fwdjets_ClusterFwd_07_eval.root");
+  evalcfwd07->Verbosity(verbosity);
+  se->registerSubsystem(evalcfwd07);
+
+  JetEvaluator *evalcfwd10 = new JetEvaluator("JETEVALUATORFWDCLUSTER10", "AntiKt_ClusterFwd_r10",
+                                        "AntiKt_Truth_r10", "g4fwdjets_ClusterFwd_10_eval.root");
+  evalcfwd10->Verbosity(verbosity);
+  se->registerSubsystem(evalcfwd10);
+
+  // JetEvaluator *eval3 = new JetEvaluator("JETEVALUATOR3",
+  //                                       "AntiKt_Full_r07",
+  //                                       "AntiKt_Truth_r07",
+  //                                       "g4fwdjets_full_07_eval.root");
+  // eval3->Verbosity(verbosity);
+  // se->registerSubsystem(eval3);
+
+  return;
+}
+#endif

--- a/common/G4_GEM_EIC.C
+++ b/common/G4_GEM_EIC.C
@@ -1,0 +1,238 @@
+#ifndef MACRO_G4GEMEIC_C
+#define MACRO_G4GEMEIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4SectorSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <string>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin, double etamax, const int N_Sector = 8);
+void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
+
+namespace Enable
+{
+  bool EGEM = false;
+  bool EGEM_FULL = true;
+  bool FGEM = false;
+  bool FGEM_ORIG = false;
+}  // namespace Enable
+
+void EGEM_Init()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 80.);
+  // extends only to -z
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -160.);
+}
+
+void FGEM_Init()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 150.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 282.);
+}
+
+void EGEMSetup(PHG4Reco *g4Reco)
+{
+  /* Careful with dimensions! If GEM station volumes overlap, e.g. with TPC volume, they will be
+   * drawn in event display but will NOT register any hits.
+   *
+   * Geometric constraints:
+   * TPC length = 211 cm --> from z = -105.5 to z = +105.5
+   */
+  float thickness = 3.;
+  if (Enable::EGEM_FULL){
+    make_GEM_station("EGEM_0", g4Reco, -20.5 + thickness, -0.94, -1.95);
+    make_GEM_station("EGEM_1", g4Reco, -69.5 + thickness, -2.07, -3.21);
+    make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
+    make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);
+  } else {
+    make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
+    make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);    
+  }
+}
+
+void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
+               const double min_eta = 1.245               //
+)
+{
+  const double tilt = .1;
+
+  string name;
+  double etamax;
+  double etamin;
+  double zpos;
+  PHG4SectorSubsystem *gem;
+
+  if(Enable::FGEM_ORIG){
+  	make_GEM_station("FGEM_0", g4Reco, 17.5, 0.94, 1.95, N_Sector);
+  	make_GEM_station("FGEM_1", g4Reco, 66.5, 2.07, 3.20, N_Sector);
+  }
+  ///////////////////////////////////////////////////////////////////////////
+
+  name = "FGEM_2";
+  if(Enable::FGEM_ORIG){
+  	etamax = 3.3;
+  }
+  else{
+	etamax = 2;
+  }
+  etamin = min_eta;
+  zpos = 134.0;
+
+  gem = new PHG4SectorSubsystem(name);
+
+  gem->get_geometry().set_normal_polar_angle(tilt);
+  gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+  gem->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->OverlapCheck(Enable::OVERLAPCHECK);
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  name = "FGEM_3";
+  etamax = 3.3;
+  etamin = min_eta;
+  zpos = 157.0;
+
+  gem = new PHG4SectorSubsystem(name + "_LowerEta");
+  gem->SuperDetector(name);
+
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax) - tilt)) * sin(tilt);
+
+  gem->get_geometry().set_normal_polar_angle((PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax)) / 2);
+  gem->get_geometry().set_normal_start(
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  gem->OverlapCheck(Enable::OVERLAPCHECK);
+  g4Reco->registerSubsystem(gem);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  name = "FGEM_4";
+  etamax = 3.5;
+  etamin = min_eta;
+  zpos = 271.0;
+  gem = new PHG4SectorSubsystem(name);
+
+  gem->SuperDetector(name);
+  gem->get_geometry().set_normal_polar_angle(tilt);
+  gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->OverlapCheck(Enable::OVERLAPCHECK);
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt)) * sin(tilt);
+
+  gem = new PHG4SectorSubsystem(name + "_LowerEta");
+  gem->SuperDetector(name);
+
+  gem->get_geometry().set_normal_polar_angle((PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+  gem->get_geometry().set_normal_start(
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  gem->OverlapCheck(Enable::OVERLAPCHECK);
+  g4Reco->registerSubsystem(gem);
+}
+
+//! Add drift layers to mini TPC
+void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
+{
+  assert(gem);
+
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = 0.1 * cm;
+  const double um = 1e-3 * mm;
+
+  //  const int N_Layers = 70; // used for mini-drift TPC timing digitalization
+  const int N_Layers = 1;  // simplified setup
+  const double thickness = 2 * cm;
+
+  gem->get_geometry().AddLayer("EntranceWindow", "G4_MYLAR", 25 * um, false, 100);
+  gem->get_geometry().AddLayer("Cathode", "G4_GRAPHITE", 10 * um, false, 100);
+
+  for (int d = 1; d <= N_Layers; d++)
+  {
+    ostringstream s;
+    s << "DriftLayer_";
+    s << d;
+
+    gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers, true);
+  }
+}
+
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8)
+{
+  //  cout
+  //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+  //      << name << endl;
+
+  double polar_angle = 0;
+
+  if (zpos < 0)
+  {
+    zpos = -zpos;
+    polar_angle = M_PI;
+  }
+  if (etamax < etamin)
+  {
+    double t = etamax;
+    etamax = etamin;
+    etamin = t;
+  }
+
+  PHG4SectorSubsystem *gem;
+  gem = new PHG4SectorSubsystem(name);
+
+  gem->SuperDetector(name);
+
+  gem->get_geometry().set_normal_polar_angle(polar_angle);
+  gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm());
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+  gem->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->OverlapCheck(Enable::OVERLAPCHECK);
+
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
+  return 0;
+}
+#endif

--- a/common/G4_Mvtx_EIC.C
+++ b/common/G4_Mvtx_EIC.C
@@ -1,0 +1,89 @@
+#ifndef MACRO_G4MVTXEIC_C
+#define MACRO_G4MVTXEIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4mvtx/PHG4EICMvtxSubsystem.h>
+#include <g4mvtx/PHG4MvtxDefs.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+#include <cmath>
+#include <vector>
+
+R__LOAD_LIBRARY(libg4mvtx.so)
+
+namespace Enable
+{
+  bool MVTX = false;
+  bool MVTX_OVERLAPCHECK = false;
+  int MVTX_VERBOSITY = 0;
+
+}  // namespace Enable
+
+namespace G4MVTX
+{
+  int n_maps_layer = 3;  // must be 0-3, setting it to zero removes Mvtx completely, n < 3 gives the first n layers
+  vector<int> N_staves = {18, 24, 30};
+  vector<double> nom_radius = {36.4, 48.1, 59.8};
+}  // namespace G4MVTX
+
+void MvtxInit(int verbosity = 0)
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4MVTX::nom_radius[G4MVTX::n_maps_layer - 1] / 10. + 0.7);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 16.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -17.);
+}
+
+double Mvtx(PHG4Reco* g4Reco, double radius,
+            const int absorberactive = 0)
+{
+  bool maps_overlapcheck = Enable::OVERLAPCHECK || Enable::MVTX_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
+
+  // Update EIC MAPS layer structure based on inner two layers of U. Birmingham tracker
+
+  PHG4EICMvtxSubsystem* mvtx = new PHG4EICMvtxSubsystem("MVTX");
+  mvtx->Verbosity(verbosity);
+
+  // H?kan Wennl?f <hwennlof@kth.se> :
+  //    Without time-stamping layer:
+  //    Stave type  Length  Overlap Radius [mm] Tilt  Radiation length  Number of staves
+  //    ALICE inner 270 mm  2 mm  36.4  12.0 deg  0.3 % X0  18
+  //    ALICE inner 270 mm  2 mm  59.8  12.0 deg  0.3 % X0  30
+  //    ALICE outer 840 mm  4 mm  133.8 6.0 deg 0.8 % X0  16
+  //    ALICE outer 840 mm  4 mm  180 6.0 deg 0.8 % X0  21
+
+  //    int N_staves[G4MVTX::n_maps_layer] = {18, 24, 30};
+  //    double nom_radius[G4MVTX::n_maps_layer] = {36.4, 48.1,  59.8};
+  if (G4MVTX::N_staves.size() < G4MVTX::n_maps_layer)
+  {
+    cout << "vector<int> N_staves too small: " << G4MVTX::N_staves.size()
+         << " needs to be at least of size " << G4MVTX::n_maps_layer << endl;
+    gSystem->Exit(1);
+  }
+  if (G4MVTX::nom_radius.size() < G4MVTX::n_maps_layer)
+  {
+    cout << "vector<double> nom_radius too small: " << G4MVTX::nom_radius.size()
+         << " needs to be at least of size " << G4MVTX::n_maps_layer << endl;
+    gSystem->Exit(1);
+  }
+  for (int ilyr = 0; ilyr < G4MVTX::n_maps_layer; ilyr++)
+  {
+    mvtx->set_int_param(ilyr, "active", 1);  //non-automatic initialization in PHG4DetectorGroupSubsystem
+    mvtx->set_int_param(ilyr, "layer", ilyr);
+    mvtx->set_int_param(ilyr, "N_staves", G4MVTX::N_staves[ilyr]);
+    mvtx->set_double_param(ilyr, "layer_nominal_radius", G4MVTX::nom_radius[ilyr]);  // mm
+    mvtx->set_double_param(ilyr, "phitilt", 12.0 * 180. / M_PI + M_PI);
+    mvtx->set_double_param(ilyr, "phi0", 0);
+  }
+
+  mvtx->set_string_param(PHG4MvtxDefs::GLOBAL, "stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v1.gdml"));
+  mvtx->SetActive(1);
+  mvtx->OverlapCheck(maps_overlapcheck);
+  g4Reco->registerSubsystem(mvtx);
+  return G4MVTX::nom_radius[G4MVTX::n_maps_layer - 1] / 10.;  // return cm
+}
+#endif

--- a/common/G4_Pipe_EIC.C
+++ b/common/G4_Pipe_EIC.C
@@ -1,0 +1,125 @@
+#ifndef MACRO_G4PIPEEIC_C
+#define MACRO_G4PIPEEIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4GDMLSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <TSystem.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+// This creates the Enable Flag to be used in the main steering macro
+namespace Enable
+{
+  bool PIPE = false;
+  bool PIPE_ABSORBER = false;
+  bool PIPE_OVERLAPCHECK = false;
+  int PIPE_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4PIPE
+{
+  // Central pipe dimension
+  // Extracted via mechanical model: Detector chamber 3-20-20
+  // directly implimenting the central Be section in G4 cylinder for max speed simulation in the detector region.
+  // The jointer lip structure of the pipe R = 3.2cm x L=5mm is ignored here
+  double be_pipe_radius = 3.1000;
+  double be_pipe_thickness = 3.1762 - be_pipe_radius;  // 760 um for sPHENIX
+  double be_pipe_length_plus = 66.8;                   // +z beam pipe extend.
+  double be_pipe_length_neg = -79.8;                   // -z beam pipe extend.
+  bool use_forward_pipes = false;
+}  // namespace G4PIPE
+
+void PipeInit()
+{
+  if (G4PIPE::use_forward_pipes)
+  {
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 23.);
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 450.);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -463.);
+  }
+  else
+  {
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4PIPE::be_pipe_radius + G4PIPE::be_pipe_thickness);
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4PIPE::be_pipe_length_plus);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, G4PIPE::be_pipe_length_neg);
+  }
+}
+
+//! construct beam pipe
+double Pipe(PHG4Reco* g4Reco,
+            double radius)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::PIPE_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::PIPE_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::PIPE_VERBOSITY);
+  // process pipe extentions?
+  const bool do_pipe_hadron_forward_extension = G4PIPE::use_forward_pipes && true;
+  const bool do_pipe_electron_forward_extension = G4PIPE::use_forward_pipes && true;
+
+  const double be_pipe_length = G4PIPE::be_pipe_length_plus - G4PIPE::be_pipe_length_neg;  // pipe length
+  const double be_pipe_center = 0.5 * (G4PIPE::be_pipe_length_plus + G4PIPE::be_pipe_length_neg);
+
+  if (radius > G4PIPE::be_pipe_radius)
+  {
+    cout << "inconsistency: radius: " << radius
+         << " larger than pipe inner radius: " << G4PIPE::be_pipe_radius << endl;
+    gSystem->Exit(-1);
+  }
+
+  // mid-rapidity beryillium pipe
+  PHG4CylinderSubsystem* cyl = new PHG4CylinderSubsystem("VAC_BE_PIPE", 0);
+  cyl->set_double_param("radius", 0.0);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", be_pipe_length);
+  cyl->set_double_param("place_z", be_pipe_center);
+  cyl->set_string_param("material", "G4_Galactic");
+  cyl->set_double_param("thickness", G4PIPE::be_pipe_radius);
+  cyl->SuperDetector("PIPE");
+  cyl->OverlapCheck(OverlapCheck);
+  if (AbsorberActive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  cyl = new PHG4CylinderSubsystem("BE_PIPE", 1);
+  cyl->set_double_param("radius", G4PIPE::be_pipe_radius);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", be_pipe_length);
+  cyl->set_double_param("place_z", be_pipe_center);
+  cyl->set_string_param("material", "G4_Be");
+  cyl->set_double_param("thickness", G4PIPE::be_pipe_thickness);
+  cyl->SuperDetector("PIPE");
+  cyl->OverlapCheck(OverlapCheck);
+  if (AbsorberActive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  radius = G4PIPE::be_pipe_radius + G4PIPE::be_pipe_thickness;
+
+  radius += no_overlapp;
+
+  if (do_pipe_electron_forward_extension)
+  {
+    PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("ElectronForwardEnvelope");
+    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector_chamber_3-20-20.G4Import.gdml");
+    gdml->set_string_param("TopVolName", "ElectronForwardEnvelope");
+    gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+    gdml->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(gdml);
+  }
+
+  if (do_pipe_hadron_forward_extension)
+  {
+    PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardEnvelope");
+    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector_chamber_3-20-20.G4Import.gdml");
+    gdml->set_string_param("TopVolName", "HadronForwardEnvelope");
+    gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+    gdml->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(gdml);
+  }
+
+  return radius;
+}
+#endif

--- a/common/G4_Piston.C
+++ b/common/G4_Piston.C
@@ -1,0 +1,122 @@
+#ifndef MACRO_G4PISTON_C
+#define MACRO_G4PISTON_C
+
+#include <GlobalVariables.C>
+
+#include <G4_Pipe.C>
+
+#include <g4detectors/PHG4ConeSubsystem.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+namespace Enable
+{
+  bool PISTON = false;
+  bool PISTON_ABSORBER = false;
+  bool PISTON_OVERLAPCHECK = false;
+  int PISTON_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4PISTON
+{
+  double zpos1 = 305. - 20.;                       // front of forward ECal/MPC
+  double zpos2 = 335.9 - 10.2 / 2.;                // front of the forward field endcap
+  double calorimeter_hole_diameter = 9.92331 * 2;  // side length of the middle hole of MPC that
+}  // namespace G4PISTON
+
+void PistonInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4PISTON::calorimeter_hole_diameter / 2.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, ((G4PISTON::zpos2 + G4PISTON::zpos1) / 2. + (G4PISTON::zpos2 - G4PISTON::zpos1) / 2.));
+}
+
+void Piston(PHG4Reco *g4Reco,
+            const int absorberactive = 0)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::PISTON_ABSORBER || absorberactive;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::PISTON_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::PISTON_VERBOSITY);
+
+  string name = "magpiston";
+  const double zpos0 = G4PIPE::al_pipe_length + G4PIPE::be_pipe_length * 0.5;  // first large GEM station
+
+  const double beampipe_radius = G4PIPE::be_pipe_radius;
+
+  // teeth cone section specific
+  const double number_of_wteeth = 100;
+  const double teeth_thickness = 0.3504 * 2;  //2 X0
+  const double eta_inner = -log(tan(atan((beampipe_radius + 0.1) / zpos0) / 2));
+  const double eta_outter = 4.2;
+  const double eta_teeth_outter = 4.05;
+  double pos = zpos0 + (G4PISTON::zpos1 - zpos0) / 2;
+  //  cout << "MAGNETIC PISTON:" << eta_inner << " " << eta_outter << " " << pos
+  //      << endl;
+
+  PHG4ConeSubsystem *magpiston = new PHG4ConeSubsystem("Piston", 0);
+  magpiston->SetZlength((G4PISTON::zpos1 - zpos0) / 2);
+  magpiston->SetPlaceZ((G4PISTON::zpos1 + zpos0) / 2);
+  magpiston->SetR1(beampipe_radius,
+                   tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter)) * zpos0);
+  magpiston->SetR2(beampipe_radius,
+                   tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter)) * G4PISTON::zpos1);
+  magpiston->SetMaterial("G4_Fe");
+  magpiston->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(magpiston);
+
+  //  PHG4ConeSubsystem *magpiston = new PHG4ConeSubsystem(name, 1);
+  //  magpiston->SetZlength((G4PISTON::zpos1 - zpos0) / 2);
+  //  magpiston->SetPlaceZ(pos);
+  //  magpiston->Set_eta_range(eta_outter, eta_inner);
+  //  magpiston->SetMaterial("G4_Fe");
+  //  magpiston->SuperDetector(name);
+  //  magpiston->SetActive(false);
+  //  g4Reco->registerSubsystem(magpiston);
+
+  pos = zpos0 + 1.0 + teeth_thickness / 2;
+  for (int i = 0; i < number_of_wteeth; i++)
+  {
+    stringstream s;
+    s << name;
+    s << "_teeth_";
+    s << i;
+
+    magpiston = new PHG4ConeSubsystem(s.str(), i);
+    magpiston->SuperDetector(name);
+    magpiston->SetZlength(teeth_thickness / 2);
+    magpiston->SetPlaceZ(pos);
+    magpiston->SetR1(
+        //
+        tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01)) * (pos - teeth_thickness / 2),  //
+        tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_teeth_outter)) * (pos - teeth_thickness / 2)   //
+    );
+    magpiston->SetR2(
+        //
+        tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01)) * (pos + teeth_thickness / 2),      //
+        tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01)) * (pos + teeth_thickness / 2) + .1  //
+    );
+    magpiston->SetMaterial("G4_W");
+    magpiston->SuperDetector(name);
+    if (AbsorberActive) magpiston->SetActive();
+    magpiston->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(magpiston);
+    pos += ((G4PISTON::zpos1 - zpos0 - 10) / number_of_wteeth);
+  }
+
+  // last piece connect to the field return
+  PHG4CylinderSubsystem *magpiston2 = new PHG4CylinderSubsystem("Piston_EndSection", 0);
+  magpiston2->set_double_param("length", G4PISTON::zpos2 - G4PISTON::zpos1);
+  magpiston2->set_double_param("place_z", (G4PISTON::zpos2 + G4PISTON::zpos1) / 2.);
+  magpiston2->set_double_param("radius", beampipe_radius);
+  magpiston2->set_double_param("thickness", G4PISTON::calorimeter_hole_diameter / 2. - beampipe_radius);
+  magpiston2->set_string_param("material", "G4_Fe");
+  magpiston2->SuperDetector(name);
+  if (AbsorberActive) magpiston2->SetActive();
+  magpiston2->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(magpiston2);
+
+  return;
+}
+#endif

--- a/common/G4_PlugDoor_EIC.C
+++ b/common/G4_PlugDoor_EIC.C
@@ -1,0 +1,59 @@
+#ifndef MACRO_G4PLUGDOOREIC_C
+#define MACRO_G4PLUGDOOREIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+namespace Enable
+{
+  bool PLUGDOOR = false;
+  bool PLUGDOOR_ABSORBER = false;
+  bool PLUGDOOR_OVERLAPCHECK = false;
+}  // namespace Enable
+
+namespace G4PLUGDOOR
+{
+  // sPHENIX forward flux return(s)
+  // define via four corners in the engineering drawing
+  double z_1 = 330.81;
+  double z_2 = 360.81;
+  double r_1 = 30;
+  double r_2 = 263.5;
+
+  double length = z_2 - z_1;
+  double place_z = -(z_1 + z_2) / 2.;
+}  // namespace G4PLUGDOOR
+
+void PlugDoorInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4PLUGDOOR::r_2);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, G4PLUGDOOR::place_z - G4PLUGDOOR::length / 2.);
+}
+
+void PlugDoor(PHG4Reco *g4Reco)
+{
+  //----------------------------------------
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::PLUGDOOR_OVERLAPCHECK;
+  const bool flux_door_active = Enable::ABSORBER || Enable::PLUGDOOR_ABSORBER;
+
+  const string material("Steel_1006");
+
+  PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FLUXRET_ETA_MINUS", 0);
+  flux_return_minus->set_double_param("length", G4PLUGDOOR::length);
+  flux_return_minus->set_double_param("radius", G4PLUGDOOR::r_1);
+  flux_return_minus->set_double_param("place_z", G4PLUGDOOR::place_z);
+  flux_return_minus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1);
+  flux_return_minus->set_string_param("material", material);
+  flux_return_minus->SetActive(flux_door_active);
+  flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+  flux_return_minus->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(flux_return_minus);
+
+  return;
+}
+#endif

--- a/common/G4_PlugDoor_fsPHENIX.C
+++ b/common/G4_PlugDoor_fsPHENIX.C
@@ -1,0 +1,67 @@
+#ifndef MACRO_G4PLUGDOORFSPHENIX_C
+#define MACRO_G4PLUGDOORFSPHENIX_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+namespace Enable
+{
+  bool PLUGDOOR = false;
+  bool PLUGDOOR_ABSORBER = false;
+  bool PLUGDOOR_OVERLAPCHECK = false;
+}  // namespace Enable
+
+namespace G4PLUGDOOR
+{
+  double place_z = 335.9;
+  double length = 10.2;
+  double inner_radius = 2.1;
+  double thickness = 258.5;
+}  // namespace G4PLUGDOOR
+
+void PlugDoorInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4PLUGDOOR::inner_radius + G4PLUGDOOR::thickness);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4PLUGDOOR::place_z + G4PLUGDOOR::length / 2.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -(G4PLUGDOOR::place_z + G4PLUGDOOR::length / 2.));
+}
+
+void PlugDoor(PHG4Reco *g4Reco)
+{
+  //----------------------------------------
+  // fsPHENIX forward flux return(s)
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::PLUGDOOR_OVERLAPCHECK;
+  bool flux_door_active = Enable::ABSORBER || Enable::PLUGDOOR_ABSORBER;
+
+  const string material("Steel_1006");
+
+  PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
+  flux_return_plus->set_double_param("length", G4PLUGDOOR::length);
+  flux_return_plus->set_double_param("radius", G4PLUGDOOR::inner_radius);
+  flux_return_plus->set_double_param("place_z", G4PLUGDOOR::place_z);
+  flux_return_plus->set_double_param("thickness", G4PLUGDOOR::thickness);
+  flux_return_plus->set_string_param("material", material);
+  flux_return_plus->SetActive(flux_door_active);
+  flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
+  flux_return_plus->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(flux_return_plus);
+
+  PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
+  flux_return_minus->set_double_param("length", G4PLUGDOOR::length);
+  flux_return_minus->set_double_param("radius", G4PLUGDOOR::inner_radius);
+  flux_return_minus->set_double_param("place_z", -G4PLUGDOOR::place_z);
+  flux_return_minus->set_double_param("thickness", G4PLUGDOOR::thickness);
+  flux_return_minus->set_string_param("material", material);
+  flux_return_minus->SetActive(flux_door_active);
+  flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+  flux_return_minus->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(flux_return_minus);
+
+  return;
+}
+#endif

--- a/common/G4_RICH.C
+++ b/common/G4_RICH.C
@@ -1,0 +1,64 @@
+/*!
+ * \file G4_RICH.C
+ * \brief Setup the gas RICH detector as designed in ePHENIX LOI
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.2 $
+ * \date $Date: 2013/10/09 01:08:17 $
+ */
+#ifndef MACRO_G4RICH_C
+#define MACRO_G4RICH_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4RICHSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+namespace Enable
+{
+  bool RICH = false;
+}
+
+void RICHInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 135.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 268.);
+}
+
+//! ePHENIX Gas RICH. Ref to Geometry parameter defined in ePHENIXRICH::RICH_Geometry
+//! \param[in] N_RICH_Sector number of RICH sectors
+//! \param[in] min_eta minimal eta coverage
+//! \param[in] R_mirror_ref Radius for the reflection layer of the mirror
+void RICHSetup(PHG4Reco* g4Reco,                   //
+               const int N_RICH_Sector = 8,        //
+               const double min_eta = 1.3,         //
+               const double R_mirror_ref = 190,    //cm // Reduced from 195 (2014 LOI) -> 190 to avoid overlap with FGEM4 (it seems to fit fine in the AutoCAD drawing- is the RICH longer in Geant4 than in the AutoCAD drawing?)
+               const double z_shift = 75,          // cm
+               const double R_shift = 18.5,        // cm
+               const double R_beampipe_front = 8,  // clearance for EIC beam pipe flange
+               const double R_beampipe_back = 27   // clearance for EIC beam pipe flange
+)
+{
+  /* Use dedicated RICH subsystem */
+  PHG4RICHSubsystem* rich = new PHG4RICHSubsystem("RICH");
+  rich->get_RICH_geometry().set_N_RICH_Sector(N_RICH_Sector);
+  rich->get_RICH_geometry().set_min_eta(min_eta);
+
+  //  rich->get_RICH_geometry().set_R_shift(10 * ePHENIXRICH::RICH_Geometry::Unit_cm()); // For compact RICH of 2<Eta<4
+
+  rich->get_RICH_geometry().set_R_mirror_ref(R_mirror_ref * ePHENIXRICH::RICH_Geometry::Unit_cm());
+
+  rich->get_RICH_geometry().set_z_shift(z_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
+  rich->get_RICH_geometry().set_R_shift(R_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
+
+  rich->get_RICH_geometry().set_R_beam_pipe_front(R_beampipe_front * ePHENIXRICH::RICH_Geometry::Unit_cm());
+  rich->get_RICH_geometry().set_R_beam_pipe_back(R_beampipe_back * ePHENIXRICH::RICH_Geometry::Unit_cm());
+
+  rich->OverlapCheck(Enable::OVERLAPCHECK);
+
+  /* Register RICH module */
+  g4Reco->registerSubsystem(rich);
+}
+#endif

--- a/common/G4_TPC_EIC.C
+++ b/common/G4_TPC_EIC.C
@@ -1,0 +1,154 @@
+#ifndef MACRO_G4TPCEIC_C
+#define MACRO_G4TPCEIC_C
+
+#include <GlobalVariables.C>
+
+#include <G4_Mvtx_EIC.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4tpc/PHG4TpcEndCapSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+#include <cmath>
+#include <vector>
+
+R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libg4mvtx.so)
+R__LOAD_LIBRARY(libg4tpc.so)
+
+namespace Enable
+{
+  bool TPC = false;
+  bool TPC_ENDCAP = false;
+  bool TPC_ABSORBER = false;
+  bool TPC_OVERLAPCHECK = false;
+}  // namespace Enable
+
+namespace G4TPC
+{
+  int n_tpc_layer_inner = 16;
+  double tpc_layer_thick_inner = 1.25;  // EIC- recover default inner radius of TPC vol.
+  int tpc_layer_rphi_count_inner = 1152;
+
+  int n_tpc_layer_mid = 16;
+  double tpc_layer_thick_mid = 1.25;
+  int tpc_layer_rphi_count_mid = 1536;
+
+  int n_tpc_layer_outer = 16;
+  double tpc_layer_thick_outer = 1.125;  // outer later reach from 60-78 cm (instead of 80 cm), that leads to radial thickness of 1.125 cm
+  int tpc_layer_rphi_count_outer = 2304;
+
+  double outer_radius = 78.;
+  double inner_cage_radius = 20.;
+  double cage_length = 211.0;  // From TPC group, gives eta = 1.1 at 78 cm
+  double n_rad_length_cage = 1.13e-02;
+  double cage_thickness = 28.6 * n_rad_length_cage;  // Kapton X_0 = 28.6 cm  // mocks up Kapton + carbon fiber structure
+
+  string tpcgas = "sPHENIX_TPC_Gas";  //  Ne(90%) CF4(10%) - defined in g4main/PHG4Reco.cc
+
+}  // namespace G4TPC
+
+void TPCInit()
+{
+  //  BlackHoleGeometry::max_radius set at the end of the TPC function
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4TPC::cage_length / 2.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -G4TPC::cage_length / 2.);
+}
+
+//! TPC end cap, wagon wheel, electronics
+void TPC_Endcaps(PHG4Reco* g4Reco)
+{
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TPC_OVERLAPCHECK;
+  bool AbsorberActive = Enable::ABSORBER || Enable::TPC_ABSORBER;
+
+  PHG4TpcEndCapSubsystem* tpc_endcap = new PHG4TpcEndCapSubsystem("TPC_ENDCAP");
+  tpc_endcap->SuperDetector("TPC_ENDCAP");
+
+  if (AbsorberActive) tpc_endcap->SetActive();
+  tpc_endcap->OverlapCheck(OverlapCheck);
+
+  //  tpc_endcap->set_int_param("construction_verbosity", 2);
+
+  g4Reco->registerSubsystem(tpc_endcap);
+
+  return;
+}
+
+double TPC(PHG4Reco* g4Reco, double radius,
+           const int absorberactive = 0,
+           int verbosity = 0)
+{
+  // time projection chamber layers --------------------------------------------
+
+  PHG4CylinderSubsystem* cyl;
+
+  radius = G4TPC::inner_cage_radius;
+
+  // inner field cage
+  cyl = new PHG4CylinderSubsystem("FIELDCAGE", G4MVTX::n_maps_layer);
+  cyl->set_double_param("radius", radius);
+  cyl->set_double_param("length", G4TPC::cage_length);
+  cyl->set_string_param("material", "G4_KAPTON");
+  cyl->set_double_param("thickness", G4TPC::cage_thickness);
+  cyl->SuperDetector("FIELDCAGE");
+  cyl->Verbosity(0);
+  g4Reco->registerSubsystem(cyl);
+
+  radius += G4TPC::cage_thickness;
+
+  // double inner_readout_radius = radius;
+  //  if (inner_readout_radius < radius) inner_readout_radius = radius;
+  //
+  //
+
+  int n_tpc_layers[3] = {16, 16, 16};
+  int tpc_layer_rphi_count[3] = {1152, 1536, 2304};
+
+  double tpc_region_thickness[3] = {20., 20., 18.};
+  // Active layers of the TPC (inner layers)
+  int nlayer = G4MVTX::n_maps_layer;
+  for (int irange = 0; irange < 3; irange++)
+  {
+    double tpc_layer_thickness = tpc_region_thickness[irange] / n_tpc_layers[irange];  // thickness per layer
+    for (int ilayer = 0; ilayer < n_tpc_layers[irange]; ilayer++)
+    {
+      cyl = new PHG4CylinderSubsystem("TPC", nlayer);
+      cyl->set_double_param("radius", radius);
+      cyl->set_double_param("length", G4TPC::cage_length);
+      cyl->set_string_param("material", G4TPC::tpcgas);
+      cyl->set_double_param("thickness", tpc_layer_thickness - 0.01);
+      cyl->SetActive();
+      cyl->SuperDetector("TPC");
+      g4Reco->registerSubsystem(cyl);
+
+      radius += tpc_layer_thickness;
+      nlayer++;
+    }
+  }
+
+  // outer field cage
+  cyl = new PHG4CylinderSubsystem("FIELDCAGE", nlayer);
+  cyl->set_double_param("radius", radius);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", G4TPC::cage_length);
+  cyl->set_string_param("material", "G4_KAPTON");
+  cyl->set_double_param("thickness", G4TPC::cage_thickness);  // Kapton X_0 = 28.6 cm
+  cyl->SuperDetector("FIELDCAGE");
+  g4Reco->registerSubsystem(cyl);
+
+  radius += G4TPC::cage_thickness;
+
+  if (Enable::TPC_ENDCAP)
+  {
+    TPC_Endcaps(g4Reco);
+  }
+  // update now that we know the outer radius
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, radius);
+  return radius;
+}
+
+#endif

--- a/common/G4_Tracking_EIC.C
+++ b/common/G4_Tracking_EIC.C
@@ -1,0 +1,282 @@
+#ifndef MACRO_G4TRACKINGEIC_C
+#define MACRO_G4TRACKINGEIC_C
+
+#include <GlobalVariables.C>
+
+#include <G4_CEmc_EIC.C>
+#include <G4_FEMC_EIC.C>
+#include <G4_FHCAL.C>
+#include <G4_GEM_EIC.C>
+#include <G4_Mvtx_EIC.C>
+#include <G4_TPC_EIC.C>
+
+#include <g4trackfastsim/PHG4TrackFastSim.h>
+
+#include <trackreco/PHRaveVertexing.h>
+
+#include <g4trackfastsim/PHG4TrackFastSimEval.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+#include <vector>
+
+R__LOAD_LIBRARY(libtrack_reco.so)
+R__LOAD_LIBRARY(libg4trackfastsim.so)
+
+namespace Enable
+{
+  bool TRACKING = false;
+  bool TRACKING_EVAL = false;
+  int TRACKING_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4TRACKING
+{
+  bool DISPLACED_VERTEX = false;
+  bool PROJECTION_EEMC = false;
+  bool PROJECTION_CEMC = false;
+  bool PROJECTION_FEMC = false;
+  bool PROJECTION_FHCAL = false;
+}  // namespace G4TRACKING
+
+//-----------------------------------------------------------------------------//
+void TrackingInit()
+{
+  TRACKING::TrackNodeName = "TrackMap";
+}
+//-----------------------------------------------------------------------------//
+void Tracking_Reco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4TrackFastSim *kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
+  kalman->Verbosity(verbosity);
+  //  kalman->Smearing(false);
+  if (G4TRACKING::DISPLACED_VERTEX)
+  {
+    // do not use truth vertex in the track fitting,
+    // which would lead to worse momentum resolution for prompt tracks
+    // but this allows displaced track analysis including DCA and vertex finding
+    kalman->set_use_vertex_in_fitting(false);
+    kalman->set_vertex_xy_resolution(0);  // do not smear the vertex used in the built-in DCA calculation
+    kalman->set_vertex_z_resolution(0);   // do not smear the vertex used in the built-in DCA calculation
+    kalman->enable_vertexing(true);       // enable vertex finding and fitting
+  }
+  else
+  {
+    // constraint to a primary vertex and use it as part of the fitting level arm
+    kalman->set_use_vertex_in_fitting(true);
+    kalman->set_vertex_xy_resolution(50e-4);
+    kalman->set_vertex_z_resolution(50e-4);
+  }
+
+  kalman->set_sub_top_node_name("TRACKS");
+  kalman->set_trackmap_out_name(TRACKING::TrackNodeName);
+
+  //-------------------------
+  // Barrel
+  //-------------------------
+  if (Enable::BARREL)
+  {
+    double pitch = 20e-4 / sqrt(12);
+
+    if (G4BARREL::SETTING::BARRELV5 || G4BARREL::SETTING::BARRELV6)
+    {
+      int nLayer1 = 3;                               //barrel 1
+      int nLayer2 = 2;                               //barrel 2
+      if (G4BARREL::SETTING::BARRELV6) nLayer2 = 1;  //compactible w/ TPC
+      int nLayer[2] = {nLayer1, nLayer2};
+
+      for (int n = 0; n < 2; n++)
+      {
+        if (n == 1) pitch = 36.4e-4 / sqrt(12);
+        for (int i=0; i < nLayer[n]; i++)
+        {
+          kalman->add_phg4hits(Form("G4HIT_BARREL%d_%d", n, i),  // const std::string& phg4hitsNames,
+                               PHG4TrackFastSim::Cylinder,       // const DETECTOR_TYPE phg4dettype,
+                               5e-4,                             // const float radres,   *ignored in cylindrical detector*
+                               pitch,                            // const float phires,
+                               pitch,                            // const float lonres,
+                               0.95,                             // const float eff,
+                               0);                               // const float noise
+        }
+      }
+    }
+    else
+    {
+      int nLayer = 5;
+      if (G4BARREL::SETTING::BARRELV4) nLayer = 6;
+      for (int i=0; i < nLayer; i++)
+      {
+        kalman->add_phg4hits(Form("G4HIT_BARREL_%d", i),  // const std::string& phg4hitsNames,
+                             PHG4TrackFastSim::Cylinder,  // const DETECTOR_TYPE phg4dettype,
+                             5e-4,                        // const float radres,   *ignored in cylindrical detector*
+                             pitch,                       // const float phires,
+                             pitch,                       // const float lonres,
+                             0.95,                        // const float eff,
+                             0);                          // const float noise
+      }
+    }
+  }
+  //-------------------------
+  // MVTX
+  //-------------------------
+  if (Enable::MVTX)
+  {
+    //   MAPS
+    kalman->add_phg4hits(
+        "G4HIT_MVTX",                //      const std::string& phg4hitsNames,
+        PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+        5e-4,                        //      const float radres,
+        5e-4,                        //      const float phires,
+        5e-4,                        //      const float lonres,
+        1,                           //      const float eff,
+        0                            //      const float noise
+    );
+  }
+  //-------------------------
+  // TPC
+  //-------------------------
+  if (Enable::TPC)
+  {
+    kalman->add_phg4hits(
+        "G4HIT_TPC",                 //      const std::string& phg4hitsNames,
+        PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+        1,                           //      const float radres,
+        200e-4,                      //      const float phires,
+        500e-4,                      //      const float lonres,
+        1,                           //      const float eff,
+        0                            //      const float noise
+    );
+  }
+  //-------------------------
+  // EGEM
+  //-------------------------
+  if (Enable::EGEM)
+  {
+    // GEM, 70um azimuthal resolution, 1cm radial strips
+    for (int i = 0; i < 4; i++)
+    {
+      kalman->add_phg4hits(
+          Form("G4HIT_EGEM_%d", i),          //      const std::string& phg4hitsNames,
+          PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+          1. / sqrt(12.),                    //      const float radres,
+          70e-4,                             //      const float phires,
+          100e-4,                            //      const float lonres,
+          1,                                 //      const float eff,
+          0                                  //      const float noise
+      );
+    }
+  }
+  //-------------------------
+  // FGEM
+  //-------------------------
+  if (Enable::FGEM || Enable::FGEM_ORIG)
+  {
+    int first_gem(0);
+    if (Enable::FGEM_ORIG)
+    {
+      first_gem = 0;
+    }
+    else
+    {
+      first_gem = 2;
+    }
+    // GEM2, 70um azimuthal resolution, 1cm radial strips
+    for (int i = first_gem; i < 5; i++)
+    {
+      kalman->add_phg4hits(Form("G4HIT_FGEM_%d", i),          //      const std::string& phg4hitsNames,
+                           PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+                           1. / sqrt(12.),                    //      const float radres,
+                           70e-4,                             //      const float phires,
+                           100e-4,                            //      const float lonres,
+                           1,                                 //      const float eff,
+                           0);                                //      const float noise
+    }
+  }
+  //-------------------------
+  // FST
+  //-------------------------
+  if (Enable::FST)
+  {
+    float pitch = 20e-4;
+    int nPlane = 5;
+    if (G4FST::SETTING::FSTV4 || G4FST::SETTING::FSTV5)
+    {
+      nPlane = 6;
+    }
+
+    for (int i = 0; i < nPlane; i++)
+    {
+      if (i >= 3) pitch = 36.4e-4;
+      kalman->add_phg4hits(Form("G4HIT_FST_%d", i),           //      const std::string& phg4hitsNames,
+                           PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+                           pitch,                             //      const float radres,
+                           pitch,                             //      const float phires,
+                           50e-4 / sqrt(12.),                 //      const float lonres, *ignored in plane detector*
+                           1,                                 //      const float eff,
+                           0);                                //      const float noise
+    }
+  }
+  //-------------------------
+  // FEMC
+  //-------------------------
+  // Saved track states (projections)
+  if (Enable::FEMC && G4TRACKING::PROJECTION_FEMC)
+  {
+    kalman->add_state_name("FEMC");
+  }
+
+  //-------------------------
+  // FHCAL
+  //-------------------------
+  if (Enable::FHCAL && G4TRACKING::PROJECTION_FHCAL)
+  {
+    kalman->add_state_name("FHCAL");
+  }
+  //-------------------------
+  // CEMC
+  //-------------------------
+  if (Enable::CEMC && G4TRACKING::PROJECTION_CEMC)
+  {
+    kalman->add_state_name("CEMC");
+  }
+  //-------------------------
+  // EEMC
+  //-------------------------
+  if (Enable::EEMC && G4TRACKING::PROJECTION_EEMC)
+  {
+    kalman->add_state_name("EEMC");
+  }
+
+  se->registerSubsystem(kalman);
+  return;
+}
+
+//-----------------------------------------------------------------------------//
+
+void Tracking_Eval(const std::string &outputfile)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  //----------------
+  // Fast Tracking evaluation
+  //----------------
+
+  PHG4TrackFastSimEval *fast_sim_eval = new PHG4TrackFastSimEval("FastTrackingEval");
+  fast_sim_eval->set_trackmapname(TRACKING::TrackNodeName);
+  fast_sim_eval->set_filename(outputfile);
+  fast_sim_eval->Verbosity(verbosity);
+  se->registerSubsystem(fast_sim_eval);
+}
+#endif

--- a/common/G4_Tracking_Modular.C
+++ b/common/G4_Tracking_Modular.C
@@ -37,6 +37,7 @@ namespace G4TRACKING
   bool PROJECTION_CEMC = false;
   bool PROJECTION_FEMC = false;
   bool PROJECTION_FHCAL = false;
+  bool PROJECTION_EHCAL = false;
   bool PROJECTION_DRCALO = false;
 }  // namespace G4TRACKING
 

--- a/common/G4_hFarFwdBeamLine_EIC.C
+++ b/common/G4_hFarFwdBeamLine_EIC.C
@@ -1,0 +1,369 @@
+#ifndef MACRO_G4HFARFWDBEAMLINE_EIC_C
+#define MACRO_G4HFARFWDBEAMLINE_EIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4ConeSubsystem.h>
+#include <g4detectors/BeamLineMagnetSubsystem.h>
+#include <g4detectors/PHG4BlockSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <TSystem.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+// This creates the Enable Flag to be used in the main steering macro
+namespace Enable
+{
+  bool HFARFWD_MAGNETS_IP6 = false;
+  bool HFARFWD_MAGNETS_IP8 = false;
+  bool HFARFWD_VIRTUAL_DETECTORS_IP8 = false;
+  bool HFARFWD_VIRTUAL_DETECTORS_IP6 = false;
+  bool HFARFWD_PIPE = false;
+  bool HFARFWD_OVERLAPCHECK = false;
+  int HFARFWD_VERBOSITY = 0;
+}  // namespace Enable
+
+
+void hFarFwdBeamLineInit()
+{
+
+  if (Enable::HFARFWD_MAGNETS_IP6 && Enable::HFARFWD_MAGNETS_IP8)
+  {
+    cout << "You cannot have magnets for both IP6 and IP8 ON at the same time" << endl;
+    gSystem->Exit(1);
+  }
+
+  if (Enable::HFARFWD_MAGNETS_IP6)
+  {
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 4500.);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, 0.);
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 180.0);
+  }
+
+  if (Enable::HFARFWD_MAGNETS_IP8)
+  {
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z,  4800.);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -2050.);
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 150.0);
+  }
+}
+
+void hFarFwdDefineMagnets(PHG4Reco* g4Reco){
+
+  bool overlapCheck = Enable::OVERLAPCHECK || Enable::HFARFWD_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HFARFWD_VERBOSITY);
+
+  string magFile;
+  if(Enable::HFARFWD_MAGNETS_IP6)
+    magFile = string(getenv("CALIBRATIONROOT")) + "/Beam/ip6_h_farFwdBeamLineMagnets.dat";
+  else if(Enable::HFARFWD_MAGNETS_IP8)
+    magFile = string(getenv("CALIBRATIONROOT")) + "/Beam/ip8_35mrad_h_farFwdBeamLineMagnets.dat";
+  else{
+    cout << " You have to enable either the IP6 or IP8 Magnet configuration to define magnets! "<<endl;
+    gSystem->Exit(1);
+  }
+    
+  // make magnet active volume if you want to study the hits
+  bool magnet_active=false;
+  int absorberactive = 0;
+
+  // if you insert numbers it only displays those magnets, do not comment out the set declaration
+  set<int> magnetlist;
+  //magnetlist.insert(7);
+
+  BeamLineMagnetSubsystem *bl = nullptr;
+  std::ifstream infile(magFile);
+  if (infile.is_open())
+    {
+      double biggest_z = 0.;
+      int imagnet = 0;
+      std::string line;
+      while (std::getline(infile, line))
+	{
+	  if (! line.compare(0,1,"B") || 
+	      ! line.compare(0,1,"Q") ||
+	      ! line.compare(0,1,"S"))
+	    {
+	      std::istringstream iss(line);
+	      string magname;
+	      double x;
+	      double y;
+	      double z;
+	      double inner_radius_zin;
+	      double inner_radius_zout;
+	      double outer_magnet_diameter;
+	      double length;
+	      double angle;
+	      double dipole_field_x;
+	      double fieldgradient;
+	      if (!(iss >> magname >> x >> y >> z 
+		    >> inner_radius_zin >> inner_radius_zout
+		    >> outer_magnet_diameter >> length
+		    >> angle >> dipole_field_x >> fieldgradient))
+		{
+		  cout << "coud not decode " << line << endl;
+		  gSystem->Exit(1);
+		}
+	      else
+		{
+		  string magtype;
+		  if (inner_radius_zin != inner_radius_zout)
+		    {
+		      cout << "inner radius at front of magnet " << inner_radius_zin
+			   << " not equal radius at back of magnet " << inner_radius_zout
+			   << " needs change in code (replace tube by cone for beamline)" << endl;
+		      gSystem->Exit(1);
+		    }
+		  if(verbosity>0){
+		    cout << endl << endl << "\tID number "<<imagnet<<endl;
+		    cout << "magname: " << magname << endl;
+		    cout << "x: " << x << endl;
+		    cout << "y: " << y << endl;
+		    cout << "z: " << z << endl;
+		    cout << "inner_radius_zin: " << inner_radius_zin << endl;
+		    cout << "inner_radius_zout: " << inner_radius_zout << endl;
+		    cout << "outer_magnet_diameter: " << outer_magnet_diameter << endl;
+		    cout << "length: " << length << endl;
+		    cout << "angle: " << angle << endl;
+		    cout << "dipole_field_x: " << dipole_field_x << endl;
+		    cout << "fieldgradient: " << fieldgradient << endl;
+		  }
+		  if (! magname.compare(0,1,"B")){
+		    magtype = "DIPOLE";
+		  }else if (! magname.compare(0,1,"Q")){
+		    magtype = "QUADRUPOLE";
+		  }else if (! magname.compare(0,1,"S")){
+		    magtype = "SEXTUPOLE";
+		  }else{
+		    cout << "cannot decode magnet name " << magname << endl;
+		    gSystem->Exit(1);
+		  }
+		  // convert to our units (cm, deg)
+		  x *= 100.;
+		  y *= 100.;
+		  z *= 100.;
+		  length *= 100.;
+		  inner_radius_zin *= 100.;
+		  outer_magnet_diameter *= 100.;
+		  angle = (angle/TMath::Pi()*180.)/1000.; // given in mrad
+
+		  if (magnetlist.empty() || magnetlist.find(imagnet) != magnetlist.end())
+		    {
+		      bl = new BeamLineMagnetSubsystem("BEAMLINEMAGNET",imagnet);
+		      bl->set_double_param("field_y",dipole_field_x);
+		      bl->set_double_param("field_x",0.);
+		      bl->set_double_param("fieldgradient",fieldgradient);
+		      bl->set_string_param("magtype",magtype);
+		      bl->set_double_param("length",length);
+		      bl->set_double_param("place_x",x);
+		      bl->set_double_param("place_y",y);
+		      bl->set_double_param("place_z",z);
+		      bl->set_double_param("rot_y",angle);
+		      bl->set_double_param("inner_radius",inner_radius_zin);
+		      bl->set_double_param("outer_radius", outer_magnet_diameter/2.);
+		      bl->SetActive(magnet_active);
+		      bl->BlackHole();
+		      if (absorberactive)  
+			{
+			  bl->SetAbsorberActive();
+			}
+		      bl->OverlapCheck(overlapCheck);
+		      bl->SuperDetector("BEAMLINEMAGNET");
+		      if(verbosity)
+			bl->Verbosity(verbosity);
+		      g4Reco->registerSubsystem(bl);
+		    }
+		  imagnet++;
+		  if (fabs(z)+length > biggest_z)
+		    {
+		      biggest_z = fabs(z)+length;
+		    }
+		}
+	    }
+	}
+      infile.close();
+    }
+}
+
+void hFarFwdDefineDetectors(PHG4Reco* g4Reco){
+
+  if (Enable::HFARFWD_VIRTUAL_DETECTORS_IP6 && Enable::HFARFWD_VIRTUAL_DETECTORS_IP8)
+  {
+    cout << "You cannot have detectors enabled for both IP6 and IP8 ON at the same time" << endl;
+    gSystem->Exit(1);
+  }
+
+  if (Enable::HFARFWD_VIRTUAL_DETECTORS_IP8) {
+    cout << " IP8 h far forward detectors not defined right now. " <<endl;
+    return;
+  }
+
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HFARFWD_VERBOSITY);
+
+  auto *detZDC = new PHG4BlockSubsystem("zdcTruth");
+  detZDC->SuperDetector("ZDC");
+  detZDC->set_double_param("place_x",96.24);
+  detZDC->set_double_param("place_y",0);
+  detZDC->set_double_param("place_z",3750);
+  detZDC->set_double_param("rot_y",-0.025*TMath::RadToDeg());
+  detZDC->set_double_param("size_x",60);
+  detZDC->set_double_param("size_y",60);
+  detZDC->set_double_param("size_z",0.1);
+  detZDC->set_string_param("material","G4_Si");
+  detZDC->SetActive();
+  if(verbosity)
+    detZDC->Verbosity(verbosity);
+  g4Reco->registerSubsystem(detZDC);
+ 
+  const int rpDetNr = 2;
+  const double rp_zCent[rpDetNr]={2600  ,2800};
+  const double rp_xCent[rpDetNr]={84.49 ,93.59};
+  for(int i=0;i<rpDetNr;i++){
+    auto *detRP = new PHG4BlockSubsystem(Form("rpTruth_%d",i));
+    //detRP->SuperDetector("RomanPots");
+    detRP->set_double_param("place_x",rp_xCent[i]);
+    detRP->set_double_param("place_y",0);
+    detRP->set_double_param("place_z",rp_zCent[i]);
+    detRP->set_double_param("rot_y",-0.025*TMath::RadToDeg());
+    detRP->set_double_param("size_x",25);
+    detRP->set_double_param("size_y",10);
+    detRP->set_double_param("size_z",0.03);
+    detRP->set_string_param("material","G4_Si");
+    detRP->SetActive();
+    if(verbosity)
+      detRP->Verbosity(verbosity);
+    g4Reco->registerSubsystem(detRP);
+  }
+
+  const int b0DetNr = 4;
+  const double b0Mag_zCent = 590;
+  const double b0Mag_zLen = 120;
+  for(int i=0;i<b0DetNr;i++){
+    auto *detB0 = new PHG4CylinderSubsystem(Form("b0Truth_%d",i),0);
+    //detB0->SuperDetector("B0detectors");
+    detB0->set_double_param("radius",0);
+    detB0->set_double_param("thickness",20);
+    detB0->set_double_param("length",0.1);
+    detB0->set_string_param("material","G4_Si");
+    detB0->set_double_param("place_x",13.2);
+    detB0->set_double_param("place_y",0);
+    detB0->set_double_param("place_z", (b0Mag_zCent - b0Mag_zLen/2) + b0Mag_zLen/(b0DetNr-1) * i);
+    detB0->SetActive(true);
+    if(verbosity)
+      detB0->Verbosity(verbosity);
+    g4Reco->registerSubsystem(detB0);
+  }
+ 
+  
+}
+
+
+void hFarFwdDefineBeamPipe(PHG4Reco* g4Reco){
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HFARFWD_VERBOSITY);
+  //exit window
+  PHG4CylinderSubsystem *exitWin = new PHG4CylinderSubsystem("exitWin",0);
+  exitWin->set_double_param("radius"   ,3.2);
+  exitWin->set_double_param("thickness",11.8);
+  exitWin->set_double_param("length"   ,0.15);
+  exitWin->set_double_param("rot_y"    ,-0.025*TMath::RadToDeg());
+  exitWin->set_string_param("material" ,"G4_STAINLESS-STEEL");
+  exitWin->set_double_param("place_x"  ,12.5);
+  exitWin->set_double_param("place_y"  ,0);
+  exitWin->set_double_param("place_z"  ,500);
+  exitWin->SetActive(false);
+  g4Reco->registerSubsystem(exitWin);
+
+  //B0 magnet pipe
+  PHG4CylinderSubsystem *pipeB0 = new PHG4CylinderSubsystem("beamPipeB0",0);
+  pipeB0->set_double_param("radius",2.8);
+  pipeB0->set_double_param("thickness",0.25);
+  pipeB0->set_double_param("length",195);
+  pipeB0->set_double_param("rot_y",-0.025*TMath::RadToDeg());
+  pipeB0->set_string_param("material","G4_Al");
+  pipeB0->set_double_param("place_x",14.748);
+  pipeB0->set_double_param("place_y",0);
+  pipeB0->set_double_param("place_z",590);
+  pipeB0->SetActive(false);
+  g4Reco->registerSubsystem(pipeB0);
+
+  //Quad pipes
+  const int nSecQ = 5; //B0apf, Q1apf, Q1bpf, Q2pf, B1pf
+  const string nm  [nSecQ]={"B0apf", "Q1apf", "Q1bpf", "Q2pf", "B1pf"};
+  const double qlen[nSecQ]={160    , 150    , 220    , 440   , 330   };
+  const double qir [nSecQ]={4      , 5.1    , 7      , 12    , 12.2  };
+  const double qor [nSecQ]={4.1    , 5.2    , 7.2    , 12.2  , 12.4  };
+  const double qrot[nSecQ]={25     , 19.5   , 15     , 15    , 34    };//mrad
+  const double qxC [nSecQ]={19.8   , 24.47  , 30.05  , 39.5  , 48    };
+  const double qyC [nSecQ]={0      , 0      , 0      , 0     , 0     };
+  const double qzC [nSecQ]={770    , 922.8  , 1106.3 , 1416.7, 1806.7};
+  for(int i=0;i<nSecQ;i++){
+    PHG4CylinderSubsystem *pipe = new PHG4CylinderSubsystem(Form("beamPipe%s",nm[i].c_str()),0);
+    pipe->set_double_param("radius",qir[i]);
+    pipe->set_double_param("thickness",qor[i]-qir[i]);
+    pipe->set_double_param("length",qlen[i]);
+    pipe->set_double_param("rot_y",-qrot[i]/1000*TMath::RadToDeg());
+    pipe->set_string_param("material","G4_Al");
+    pipe->set_double_param("place_x",qxC[i]);
+    pipe->set_double_param("place_y",qyC[i]);
+    pipe->set_double_param("place_z",qzC[i]);
+    pipe->SetActive(false);
+    g4Reco->registerSubsystem(pipe);
+  }
+
+  //Electron pipe
+  PHG4CylinderSubsystem *pipeElectron = new PHG4CylinderSubsystem("beamPipeElectron",0);
+  pipeElectron->set_double_param("radius",1);
+  pipeElectron->set_double_param("thickness",1);
+  pipeElectron->set_double_param("length",3000);
+  pipeElectron->set_double_param("rot_y",-0.025*TMath::RadToDeg());
+  pipeElectron->set_string_param("material","G4_Al");
+  pipeElectron->set_double_param("place_x",0);
+  pipeElectron->set_double_param("place_y",0);
+  pipeElectron->set_double_param("place_z",2000);
+  pipeElectron->SetActive(false);
+  //g4Reco->registerSubsystem(pipeElectron);
+
+  //ZDC pipe
+  PHG4CylinderSubsystem *pipeZDC = new PHG4CylinderSubsystem("beamPipeZDC",0);
+  pipeZDC->set_double_param("radius",16.5);
+  pipeZDC->set_double_param("thickness",0.1);
+  pipeZDC->set_double_param("length",170);
+  pipeZDC->set_double_param("rot_y",-0.025*TMath::RadToDeg());
+  pipeZDC->set_string_param("material","G4_Al");
+  pipeZDC->set_double_param("place_x",59);
+  pipeZDC->set_double_param("place_y",0);
+  pipeZDC->set_double_param("place_z",2041.59);
+  pipeZDC->SetActive(false);
+  g4Reco->registerSubsystem(pipeZDC);
+
+  //Roman Pot pipe
+  const int nSec = 2;
+  const double len[nSec]={850,1150 };
+  const double ir1[nSec]={17  , 17 };
+  const double or1[nSec]={17.1,17.1};
+  const double ir2[nSec]={17  ,  7 };
+  const double or2[nSec]={17.1, 7.1};
+  const double xC[nSec] ={83  , 130};
+  const double yC[nSec] ={0   ,   0};
+  const double zC[nSec] ={2550,3550};
+  for(int i=0;i<nSec;i++){
+    PHG4ConeSubsystem *pipe = new PHG4ConeSubsystem(Form("beamPipeRP%d",i),0);
+    pipe->set_string_param("material","G4_STAINLESS-STEEL");
+    pipe->set_double_param("place_x",xC[i]);
+    pipe->set_double_param("place_y",yC[i]);
+    pipe->set_double_param("place_z",zC[i]);
+    pipe->set_double_param("length",len[i]/2);
+    pipe->set_double_param("rmin1",ir1[i]);
+    pipe->set_double_param("rmin2",ir2[i]);
+    pipe->set_double_param("rmax1",or1[i]);
+    pipe->set_double_param("rmax2",or2[i]);
+    pipe->set_double_param("rot_y",-0.027*TMath::RadToDeg());
+    g4Reco->registerSubsystem(pipe);
+  }
+}
+
+
+#endif

--- a/detectors/DualReadout/DisplayOn.C
+++ b/detectors/DualReadout/DisplayOn.C
@@ -1,0 +1,92 @@
+#ifndef MACRO_DISPLAYON_C
+#define MACRO_DISPLAYON_C
+
+#include <g4main/PHG4Reco.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libg4testbench.so)
+
+namespace Enable
+{
+  bool DISPLAY = false;
+}
+
+// This starts the QT based G4 gui which takes control
+// when x'ed out it will return a pointer to PHG4Reco so
+// the gui can be startrd again
+PHG4Reco *QTGui()
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
+  g4->StartGui();
+  return g4;
+}
+
+// stupid macro to turn on the geant4 display
+// we ask Fun4All for a pointer to PHG4Reco
+// using the ApplyCommand will start up the
+// G4 cmd interpreter and graphics system
+// the vis.mac contains the necessary commands to
+// start up the visualization, the next event will
+// be displayed. Do not execute this macro
+// before PHG4Reco was registered with Fun4All
+PHG4Reco * DisplayOn(const char *mac = "vis.mac")
+{
+  char cmd[100];
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
+  sprintf(cmd, "/control/execute %s", mac);
+  g4->ApplyCommand(cmd);
+  // draw by particle type and set nice color
+  g4->ApplyCommand("/vis/modeling/trajectories/create/drawByParticleID");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set e+ steelblue");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set e- steelblue");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set pi+ red");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set pi- red");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set kaon- mediumvioletred");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set kaon+ mediumvioletred");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set kaon0 mediumvioletred");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set proton+ orange");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set proton- orange");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set neutron lightgrey");
+  // g4->ApplyCommand("/vis/modeling/trajectories/drawByParticleID-0/set gamma wheat");
+//     g4->ApplyCommand("/vis/scene/add/trajectories smooth rich");
+  // remove neutrons and neutrinos
+  g4->ApplyCommand("/vis/filtering/trajectories/create/particleFilter");
+  // g4->ApplyCommand("/vis/filtering/trajectories/particleFilter-0/add neutron");
+  g4->ApplyCommand("/vis/filtering/trajectories/particleFilter-0/add neutrino");
+  g4->ApplyCommand("/vis/filtering/trajectories/particleFilter-0/invert true");
+
+  // set background white for presentations
+  g4->ApplyCommand("/vis/viewer/set/background white");
+
+  
+  return g4;
+}
+// print out the commands I always forget
+void displaycmd()
+{
+  cout << "draw axis: " << endl;
+  cout << " g4->ApplyCommand(\"/vis/scene/add/axes 0 0 0 50 cm\")" << endl;
+  cout << "zoom" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/zoom 1\")" << endl;
+  cout << "viewpoint:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/set/viewpointThetaPhi 0 0\")" << endl;
+  cout << "panTo:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/panTo 0 0 cm\")" << endl;
+  cout << "print to eps:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/ogl/printEPS\")" << endl;
+  cout << "set background color:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/set/background white\")" << endl;
+}
+
+
+
+#endif
+

--- a/detectors/DualReadout/Fun4All_G4_FullDetectorDualReadout.C
+++ b/detectors/DualReadout/Fun4All_G4_FullDetectorDualReadout.C
@@ -1,0 +1,613 @@
+#ifndef MACRO_FUN4ALLG4EICDETECTOR_C
+#define MACRO_FUN4ALLG4EICDETECTOR_C
+
+#include <GlobalVariables.C>
+
+#include <DisplayOn.C>
+#include <G4Setup_DualReadoutDetector.C>
+#include <G4_Bbc.C>
+#include <G4_CaloTrigger.C>
+#include <G4_DSTReader_EICDetector.C>
+#include <G4_FwdJets.C>
+#include <G4_Global.C>
+#include <G4_HIJetReco.C>
+#include <G4_Input.C>
+#include <G4_Jets.C>
+#include <G4_Production.C>
+#include <G4_User.C>
+#include <QA.C>
+
+#include <TROOT.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <PHPy6GenTrigger.h>
+#include <PHPy6ParticleTrigger.h>
+#include <PHPy6JetTrigger.h>
+#include <phool/recoConsts.h>
+
+#include <g4eval/EventEvaluator.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+
+void ParseTString(TString &specialSetting);
+
+int Fun4All_G4_FullDetectorDualReadout(
+    const int nEvents = 1,
+    const double particlemomMin = -1,
+    const double particlemomMax = -1,
+    TString specialSetting = "ALLSILICON-FTTLS3LC-ETTL-CTTL",
+    TString generatorSettings = "",
+    const string &inputFile = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
+    const string &outputFile = "G4EICDetector.root",
+    const string &embed_input_file = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
+    const int skip = 0,
+    const string &outdir = ".")
+{
+// translate the option TString into subsystem namespace options
+  ParseTString(specialSetting); 
+  //---------------
+  // Fun4All server
+  //---------------
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->Verbosity(0);
+  //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
+  //PHRandomSeed::Verbosity(1);
+
+  // just if we set some flags somewhere in this macro
+  recoConsts *rc = recoConsts::instance();
+  // By default every random number generator uses
+  // PHRandomSeed() which reads /dev/urandom to get its seed
+  // if the RANDOMSEED flag is set its value is taken as initial seed
+  // which will produce identical results so you can debug your code
+  //rc->set_IntFlag("RANDOMSEED", 12345);
+
+  //===============
+  // Input options
+  //===============
+
+  // pythia6
+  // Use Pythia 6
+  if(particlemomMin==-1 && particlemomMax==-1){
+    Input::PYTHIA6 = true;
+  }
+  // Simple multi particle generator in eta/phi/pt ranges
+  Input::SIMPLE = false;
+  if (particlemomMin>-1 && particlemomMax>-1){
+    Input::SIMPLE = true;
+    Input::SIMPLE_VERBOSITY = 0;
+ }
+  // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
+ 
+  Input::VERBOSITY = 0;
+  INPUTHEPMC::filename = inputFile;
+
+
+  Enable::QA = true;
+
+  //-----------------
+  // Initialize the selected Input/Event generation
+  //-----------------
+  InputInit();
+  //--------------
+  // Set generator specific options
+  //--------------
+  // can only be set after InputInit() is called
+
+  // Simple Input generator:
+  // if you run more than one of these Input::SIMPLE_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
+  if (Input::SIMPLE){
+    if (generatorSettings.Contains("SimplePion"))
+      INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi-", 1);
+    else if (generatorSettings.Contains("SimpleKaon"))
+      INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("kaon-", 1);
+    else if (generatorSettings.Contains("SimpleProton"))
+      INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("proton", 1);
+    else if (generatorSettings.Contains("SimplePhoton"))
+      INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("gamma", 1);
+    else if (generatorSettings.Contains("SimpleElectron"))
+      INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("e-", 1);
+    else if (generatorSettings.Contains("SimplePiZero"))
+      INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi0", 1);
+    else {
+      std::cout << "You didn't specify which particle you wanted to generate, exiting" << std::endl;
+      return 0;
+    }
+    std::cout << "running " << generatorSettings.Data() << " generation" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " generation" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " generation" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " generation" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " generation" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " generation" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " generation" << std::endl;
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
+                                                                              PHG4SimpleEventGenerator::Uniform,
+                                                                              PHG4SimpleEventGenerator::Uniform);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(2.0, 3.0);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
+    // INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(particlemomMin, particlemomMax);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_p_range(particlemomMin, particlemomMax);
+ 
+  }
+  if(particlemomMin>-1 && particlemomMax == -1){
+    std::cout << "running " << generatorSettings.Data() << " PHG4ParticleGenerator" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " PHG4ParticleGenerator" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " PHG4ParticleGenerator" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " PHG4ParticleGenerator" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " PHG4ParticleGenerator" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " PHG4ParticleGenerator" << std::endl;
+    std::cout << "running " << generatorSettings.Data() << " PHG4ParticleGenerator" << std::endl;
+    PHG4ParticleGenerator *gen = new PHG4ParticleGenerator("PGENERATOR");
+    gen->set_name("pi-");
+    gen->set_vtx(0, 0, 0);
+    gen->set_eta_range(1.5, 3.4);            // around midrapidity
+    if(particlemomMin > -1)
+      gen->set_mom_range(particlemomMin, particlemomMin);                   // fixed 4 GeV/c
+    else
+      gen->set_mom_range(5, 80);                   // fixed 4 GeV/c
+    gen->set_phi_range(0., 2* M_PI);  // 0-90 deg
+    // gen->Verbosity(1);  // 0-90 deg
+    se->registerSubsystem(gen);
+  }
+  // pythia6
+  if (Input::PYTHIA6){
+    if (generatorSettings.CompareTo("e10p250MB") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep.cfg");
+    else if (generatorSettings.CompareTo("e10p250pTHard5") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP5GeV.cfg");
+    else if (generatorSettings.CompareTo("e10p250pTHard10") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP10GeV.cfg");
+    else if (generatorSettings.CompareTo("e10p250pTHard20") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP20GeV.cfg");
+    else if (generatorSettings.CompareTo("e5p100MB") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e5p100.cfg");
+    else if (generatorSettings.CompareTo("e5p100pTHard5") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e5p100_MinPartonP5GeV.cfg");
+    else if (generatorSettings.CompareTo("e10p275MB") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275.cfg");
+    else if (generatorSettings.CompareTo("e10p275pTHard5") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275_MinPartonP5GeV.cfg");
+    else if (generatorSettings.CompareTo("e10p275pTHard10") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275_MinPartonP10GeV.cfg");
+    else if (generatorSettings.CompareTo("e18p275MB") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275.cfg");
+    else if (generatorSettings.CompareTo("e18p275pTHard5") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275_MinPartonP5GeV.cfg");
+    else if (generatorSettings.CompareTo("e18p275pTHard10") == 0)
+      INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275_MinPartonP10GeV.cfg");
+    else 
+      INPUTGENERATOR::Pythia6->set_config_file(generatorSettings.Data());
+    
+    if (specialSetting.Contains("FPartTrigg")){
+      PHPy6ParticleTrigger *ptrig = new PHPy6ParticleTrigger();
+      ptrig->SetPtLow(1);
+      ptrig->SetEtaHighLow(1,5);
+      INPUTGENERATOR::Pythia6->register_trigger(ptrig);
+    }
+    if (specialSetting.Contains("FJetTrigg")){
+      PHPy6JetTrigger *trig = new PHPy6JetTrigger();
+      trig->SetEtaHighLow(1,5);
+      if (generatorSettings.Contains("pTHard5"))
+        trig->SetMinJetPt(5);
+      else if (generatorSettings.Contains("pTHard10"))
+        trig->SetMinJetPt(10);
+      else if (generatorSettings.Contains("pTHard20"))
+        trig->SetMinJetPt(20);
+      else 
+        trig->SetMinJetPt(1);
+      trig->SetJetR(0.7);
+      INPUTGENERATOR::Pythia6->register_trigger(trig);
+    }
+  }
+
+  // register all input generators with Fun4All
+  InputRegister();
+
+
+  //======================
+  // Write the DST
+  //======================
+
+//  Enable::DSTOUT = true;
+  DstOut::OutputDir = outdir;
+  DstOut::OutputFile = outputFile;
+  Enable::DSTOUT_COMPRESS = false;  // Compress DST files
+
+  //Option to convert DST to human command readable TTree for quick poke around the outputs
+  Enable::DSTREADER = false;
+
+  // turn the display on (default off)
+  if(specialSetting.Contains("display"))
+    Enable::DISPLAY = true;
+
+  //======================
+  // What to run
+  //======================
+  // Global options (enabled for all subsystems - if implemented)
+  //  Enable::ABSORBER = true;
+  //  Enable::OVERLAPCHECK = true;
+  //  Enable::VERBOSITY = 1;
+
+  //  Enable::BBC = true;
+  Enable::BBCFAKE = true; // Smeared vtx and t0, use if you don't want real BBC in simulation
+
+  // whether to simulate the Be section of the beam pipe
+  if(!specialSetting("DRCALOONLY"))Enable::PIPE = true;
+  // EIC beam pipe extension beyond the Be-section:
+  if(!specialSetting("DRCALOONLY"))G4PIPE::use_forward_pipes = true;
+
+  if (specialSetting.Contains("EGEM"))
+    Enable::EGEM = true;
+  if (specialSetting.Contains("EGEMOO")) // only last 2 EGEM layers
+    Enable::EGEM_FULL = false;
+  //Forward GEM
+  if (specialSetting.Contains("FGEM"))
+    Enable::FGEM = true;
+  
+  // barrel tracker (LANL)
+  if (specialSetting.Contains("BARREL"))
+    Enable::BARREL = true;
+  if(specialSetting.Contains("FST"))
+    Enable::FST = true;
+  
+  // all silicon tracker version (LBL)
+  if(specialSetting.Contains("ALLSILICON")){
+    Enable::ALLSILICON = true;
+    Enable::ALLSILICON_ABSORBER = true;
+  }
+  
+  // LGAD layers
+  if(specialSetting.Contains("FTTL"))
+    Enable::FTTL = true;
+  if(specialSetting.Contains("ETTL"))
+    Enable::ETTL = true;
+  if(specialSetting.Contains("CTTL"))
+    Enable::CTTL = true;
+
+  // mvtx/tpc tracker
+  if(specialSetting.Contains("MVTX")){
+    Enable::MVTX = true;
+    Enable::TPC = true;
+  }
+  
+  if(specialSetting.Contains("ENDCAPTPC"))
+   Enable::TPC_ENDCAP = true;
+
+  Enable::TRACKING = true;
+  Enable::TRACKING_EVAL = Enable::TRACKING && true;
+  if (specialSetting.Contains("TREXTOUT"))
+    Enable::TRACKING_EVAL_DETAILED = Enable::TRACKING_EVAL && true;
+  
+  G4TRACKING::DISPLACED_VERTEX = true;  // this option exclude vertex in the track fitting and use RAVE to reconstruct primary and 2ndary vertexes
+                                         // projections to calorimeters
+  if(!specialSetting("DRCALOONLY"))G4TRACKING::PROJECTION_CEMC = true;
+  G4TRACKING::PROJECTION_DRCALO = true;
+
+ if(!specialSetting("DRCALOONLY")) Enable::CEMC = true;
+  //  Enable::CEMC_ABSORBER = true;
+  Enable::CEMC_CELL = Enable::CEMC && true;
+  Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
+  Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
+  Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
+
+  if(!specialSetting("DRCALOONLY"))Enable::HCALIN = true;
+  //  Enable::HCALIN_ABSORBER = true;
+  Enable::HCALIN_CELL = Enable::HCALIN && true;
+  Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
+  Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
+  Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && true;
+
+  // Enable::MAGNET = true;
+
+  if(!specialSetting("DRCALOONLY"))Enable::HCALOUT = true;
+  //  Enable::HCALOUT_ABSORBER = true;
+  Enable::HCALOUT_CELL = Enable::HCALOUT && true;
+  Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
+  Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
+  Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && true;
+
+  // EICDetector geometry - barrel
+  if(!specialSetting("DRCALOONLY"))Enable::DIRC = true;
+
+  // EICDetector geometry - 'hadron' direction
+  if(!specialSetting("DRCALOONLY"))Enable::RICH = true;
+  if(!specialSetting("DRCALOONLY"))Enable::AEROGEL = true;
+
+
+  Enable::DRCALO = true;
+  Enable::DRCALO_VERBOSITY = 1;
+  //  Enable::DRCALO_ABSORBER = true;
+  Enable::DRCALO_CELL = Enable::DRCALO && true;
+  Enable::DRCALO_TOWER = Enable::DRCALO_CELL && true;
+  Enable::DRCALO_CLUSTER = Enable::DRCALO_TOWER && true;
+  Enable::DRCALO_EVAL = Enable::DRCALO_CLUSTER && true;
+
+  // EICDetector geometry - 'electron' direction
+  if(!specialSetting("DRCALOONLY"))Enable::EEMC = true;
+  Enable::EEMC_CELL = Enable::EEMC && true;
+  Enable::EEMC_TOWER = Enable::EEMC_CELL && true;
+  Enable::EEMC_CLUSTER = Enable::EEMC_TOWER && true;
+  Enable::EEMC_EVAL = Enable::EEMC_CLUSTER && true;
+
+  if(!specialSetting("DRCALOONLY"))Enable::PLUGDOOR = false;
+
+  // Other options
+  Enable::GLOBAL_RECO = true;
+  Enable::GLOBAL_FASTSIM = true;
+
+  Enable::CALOTRIGGER = true && Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER;
+
+  // Select only one jet reconstruction- they currently use the same
+  // output collections on the node tree!
+  Enable::JETS = false;
+  Enable::JETS_EVAL = Enable::JETS && true;
+
+  Enable::FWDJETS = true;
+  Enable::FWDJETS_EVAL = Enable::FWDJETS && true;
+
+  // HI Jet Reco for jet simulations in Au+Au (default is false for
+  // single particle / p+p simulations, or for Au+Au simulations which
+  // don't care about jets)
+  Enable::HIJETS = false && Enable::JETS && Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER;
+
+  // new settings using Enable namespace in GlobalVariables.C
+  Enable::BLACKHOLE = true;
+  //Enable::BLACKHOLE_SAVEHITS = false; // turn off saving of bh hits
+  //BlackHoleGeometry::visible = true;
+
+  //Enable::USER = true;
+
+  //---------------
+  // World Settings
+  //---------------
+  //  G4WORLD::PhysicsList = "QGSP_BERT"; //FTFP_BERT_HP best for calo
+  //  G4WORLD::WorldMaterial = "G4_AIR"; // set to G4_GALACTIC for material scans
+
+  //---------------
+  // Magnet Settings
+  //---------------
+  if(specialSetting.Contains("3T")){
+    const string magfield = "3.0"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+    G4MAGNET::magfield = magfield;
+    //  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // default map from the calibration database
+  } else {
+    G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
+  }
+  //---------------
+  // Pythia Decayer
+  //---------------
+  // list of decay types in
+  // $OFFLINE_MAIN/include/g4decayer/EDecayType.hh
+  // default is All:
+  // G4P6DECAYER::decayType = EDecayType::kAll;
+
+  // Initialize the selected subsystems
+  G4Init();
+
+  //---------------------
+  // GEANT4 Detector description
+  //---------------------
+
+  // If "readhepMC" is also set, the Upsilons will be embedded in Hijing events, if 'particles" is set, the Upsilons will be embedded in whatever particles are thrown
+  if (!Input::READHITS) G4Setup(specialSetting);
+
+  //------------------
+  // Detector Division
+  //------------------
+  if (Enable::BBC || Enable::BBCFAKE) Bbc_Reco();
+  if (Enable::CEMC_CELL) CEMC_Cells();
+  if (Enable::HCALIN_CELL) HCALInner_Cells();
+  if (Enable::HCALOUT_CELL) HCALOuter_Cells();
+  if (Enable::EEMC_CELL) EEMC_Cells();
+
+  //-----------------------------
+  // CEMC towering and clustering
+  //-----------------------------
+  if (Enable::CEMC_TOWER) CEMC_Towers();
+  if (Enable::CEMC_CLUSTER) CEMC_Clusters();
+
+  //-----------------------------
+  // HCAL towering and clustering
+  //-----------------------------
+  if (Enable::HCALIN_TOWER) HCALInner_Towers();
+  if (Enable::HCALIN_CLUSTER) HCALInner_Clusters();
+
+  if (Enable::HCALOUT_TOWER) HCALOuter_Towers();
+  if (Enable::HCALOUT_CLUSTER) HCALOuter_Clusters();
+
+  //-----------------------------
+  // e, h direction Calorimeter  towering and clustering
+  //-----------------------------
+
+  if (Enable::DRCALO_TOWER) DRCALO_Towers();
+  if (Enable::DRCALO_CLUSTER) DRCALO_Clusters();
+
+  if (Enable::EEMC_TOWER) EEMC_Towers();
+  if (Enable::EEMC_CLUSTER) EEMC_Clusters();
+
+  if (Enable::DSTOUT_COMPRESS) ShowerCompress();
+
+  //--------------
+  // SVTX tracking
+  //--------------
+  if (Enable::TRACKING) Tracking_Reco(specialSetting);
+
+  //-----------------
+  // Global Vertexing
+  //-----------------
+  if (Enable::GLOBAL_RECO) Global_Reco();
+  else if (Enable::GLOBAL_FASTSIM) Global_FastSim();
+
+  //-----------------
+  // Calo Trigger Simulation
+  //-----------------
+  if (Enable::CALOTRIGGER) CaloTrigger_Sim();
+
+  //---------
+  // Jet reco
+  //---------
+  if (Enable::JETS) Jet_Reco();
+  if (Enable::HIJETS) HIJetReco();
+  if (Enable::FWDJETS) Jet_FwdReco();
+
+  string outputroot = outputFile;
+  string remove_this = ".root";
+  size_t pos = outputroot.find(remove_this);
+  if (pos != string::npos){
+    outputroot.erase(pos, remove_this.length());
+  }
+
+  if (Enable::DSTREADER) G4DSTreader_EICDetector(outputroot + "_DSTReader.root");
+
+  //----------------------
+  // Simulation evaluation
+  //----------------------
+  Bool_t doFullEventTree = true;
+  if(doFullEventTree){
+    EventEvaluator *eval = new EventEvaluator("EVENTEVALUATOR", "eventtree.root");
+    eval->set_reco_tracing_energy_threshold(0.02);
+    eval->Verbosity(1);
+    eval->set_do_FHCAL(false);
+    eval->set_do_FEMC(false);
+    eval->set_do_DRCALO(true);
+    // eval->set_do_HITS(true);
+    eval->set_do_TRACKS(true);
+    eval->set_do_CLUSTERS(true);
+    eval->set_do_VERTEX(true);
+    eval->set_do_PROJECTIONS(true);
+    eval->set_do_MCPARTICLES(true);
+    se->registerSubsystem(eval);
+  }
+
+  //--------------
+  // Set up Input Managers
+  //--------------
+
+  InputManagers();
+
+  //--------------
+  // Set up Output Manager
+  //--------------
+  if (Enable::PRODUCTION){
+    Production_CreateOutputDir();
+  }
+
+  if (Enable::DSTOUT){
+    string FullOutFile = DstOut::OutputDir + "/" + DstOut::OutputFile;
+    Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", FullOutFile);
+    if (Enable::DSTOUT_COMPRESS) DstCompress(out);
+    se->registerOutputManager(out);
+  }
+
+  //-----------------
+  // Event processing
+  //-----------------
+  if (Enable::DISPLAY){
+    DisplayOn();
+    gROOT->ProcessLine("Fun4AllServer *se = Fun4AllServer::instance();");
+    // gROOT->ProcessLine("PHG4Reco *g4 = QTGui();"); // alternative to DisplayOn
+    gROOT->ProcessLine("PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");");
+
+    cout << "-------------------------------------------------" << endl;
+    cout << "You are in event display mode. Run one event with" << endl;
+    cout << "se->run(1)" << endl;
+    cout << "Run Geant4 command with following examples" << endl;
+    // gROOT->ProcessLine("displaycmd()");
+
+    return 0;
+  }
+  // if we use a negative number of events we go back to the command line here
+  if (nEvents < 0){
+    return 0;
+  }
+  // if we run any of the particle generators and use 0 it'll run forever
+  if (nEvents == 0 && !Input::READHITS && !Input::HEPMC && !Input::READEIC){
+    cout << "using 0 for number of events is a bad idea when using particle generators" << endl;
+    cout << "it will run forever, so I just return without running anything" << endl;
+    return 0;
+  }
+
+  se->skip(skip);
+  se->run(nEvents);
+
+  if (Enable::QA) QA_Output(outputroot + "_qa.root");
+
+  //-----
+  // Exit
+  //-----
+
+  se->End();
+  std::cout << "All done" << std::endl;
+  delete se;
+  if (Enable::PRODUCTION){
+    Production_MoveOutput();
+  }
+  gSystem->Exit(0);
+  return 0;
+}
+
+void ParseTString(TString &specialSetting)
+{
+// Barrel settings
+  if (specialSetting.Contains("BARRELV1"))
+  {
+    G4BARREL::SETTING::BARRELV1 = true;
+  }
+  else if (specialSetting.Contains("BARRELV2"))
+  {
+    G4BARREL::SETTING::BARRELV2 = true;
+  }
+  else if (specialSetting.Contains("BARRELV3"))
+  {
+    G4BARREL::SETTING::BARRELV3 = true;
+  }
+  else if (specialSetting.Contains("BARRELV4"))
+  {
+    G4BARREL::SETTING::BARRELV4 = true;
+  }
+  else if (specialSetting.Contains("BARREL"))
+  {
+    G4BARREL::SETTING::BARRELV0 = true;
+  }
+
+// FST settings
+  if (specialSetting.Contains("FSTV1"))
+  {
+    G4FST::SETTING::FSTV1 = true;
+  }
+  else if (specialSetting.Contains("FSTV2"))
+  {
+    G4FST::SETTING::FSTV2 = true;
+  }
+  else if (specialSetting.Contains("FSTV3"))
+  {
+    G4FST::SETTING::FSTV3 = true;
+  }
+  else if (specialSetting.Contains("FSTV4"))
+  {
+    G4FST::SETTING::FSTV4 = true;
+  }
+  else if (specialSetting.Contains("FSTV41"))
+  {
+    G4FST::SETTING::FSTV41 = true;
+  }
+  else if (specialSetting.Contains("FSTV42"))
+  {
+    G4FST::SETTING::FSTV42 = true;
+  }
+  else if (specialSetting.Contains("FST"))
+  {
+    G4FST::SETTING::FSTV0 = true;
+  }
+
+// FHCAL/FEMC settings
+  if (specialSetting.Contains("DRLARGE"))
+  {
+    G4DRCALO::SETTING::LargeTowers = true;
+  }
+}
+
+#endif

--- a/detectors/DualReadout/G4Setup_DualReadoutDetector.C
+++ b/detectors/DualReadout/G4Setup_DualReadoutDetector.C
@@ -1,0 +1,311 @@
+#ifndef MACRO_G4SETUPDUALREADOUTDETECTOR_C
+#define MACRO_G4SETUPDUALREADOUTDETECTOR_C
+
+#include <GlobalVariables.C>
+
+#include <G4_Aerogel.C>
+#include <G4_Barrel_EIC.C>
+#include <G4_AllSilicon.C>
+#include <G4_FST_EIC.C>
+#include <G4_TTL_EIC.C>
+#include <G4_GEM_EIC.C>
+#include <G4_Bbc.C>
+#include <G4_BlackHole.C>
+#include <G4_CEmc_EIC.C>
+#include <G4_DIRC.C>
+#include <G4_DRCALO.C>
+#include <G4_EEMC.C>
+#include <G4_FEMC_EIC.C>
+#include <G4_FHCAL.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Input.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx_EIC.C>
+#include <G4_Pipe_EIC.C>
+#include <G4_PlugDoor_EIC.C>
+#include <G4_RICH.C>
+#include <G4_TPC_EIC.C>
+#include <G4_Tracking_Modular.C>
+#include <G4_User.C>
+#include <G4_World.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4eval/PHG4DstCompressReco.h>
+
+#include <g4main/PHG4Reco.h>
+#include <g4main/PHG4TruthSubsystem.h>
+
+#include <phfield/PHFieldConfig.h>
+
+#include <g4decayer/EDecayType.hh>
+
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libg4decayer.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+
+void G4Init()
+{
+  // First some check for subsystems which do not go together
+
+  if (Enable::TPC && Enable::FST){
+    cout << "TPC and FST cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  } else if ((Enable::TPC || Enable::MVTX) && Enable::BARREL){
+    cout << "TPC/MVTX and BARREL cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  } else if ( (Enable::FST && Enable::ALLSILICON) || 
+              (Enable::BARREL && Enable::ALLSILICON) ){
+    cout << "FST and ALLSILICON or BARREL and ALLSILICON cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  } else if ( (Enable::EGEM && Enable::ALLSILICON && Enable::EGEM_FULL) ){
+              
+    cout << "EGEM and ALLSILICON cannot be enabled together, if EGEM is using full setup, set Enable::EGEM_FULL to false to run in parallel" << endl;
+    gSystem->Exit(1);
+  } else if ( (Enable::FGEM && Enable::ALLSILICON) ) {
+    cout << "FGEM and ALLSILICON cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  } else if ( (Enable::FGEM && Enable::FTTL) ) {
+    cout << "FGEM and FTTL cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  }
+
+  // load detector/material macros and execute Init() function
+  if (Enable::PLUGDOOR) PlugDoorInit();
+  if (Enable::MAGNET) MagnetInit();
+  MagnetFieldInit(); // We want the field - even if the magnet volume is disabled
+  if (Enable::PIPE) PipeInit();
+  // trackers
+  if (Enable::EGEM) EGEM_Init();
+  if (Enable::FGEM) FGEM_Init();
+  if (Enable::FST) FST_Init();
+  if (Enable::ALLSILICON) AllSiliconInit();
+  if (Enable::FTTL || Enable::ETTL  || Enable::CTTL) TTL_Init();
+  if (Enable::BARREL) BarrelInit();
+  if (Enable::MVTX) MvtxInit();
+  if (Enable::TPC) TPCInit();
+  // PID
+  if (Enable::DIRC) DIRCInit();
+  if (Enable::RICH) RICHInit();
+  if (Enable::AEROGEL) AerogelInit();
+  
+  // calorimeters
+  if (Enable::CEMC) CEmcInit(72);  // make it 2*2*2*3*3 so we can try other combinations
+  if (Enable::HCALIN) HCalInnerInit(1);
+  if (Enable::HCALOUT) HCalOuterInit();
+  if (Enable::FEMC) FEMCInit();
+  if (Enable::FHCAL) FHCALInit();
+  if (Enable::DRCALO) DRCALOInit();
+  if (Enable::EEMC) EEMCInit();
+  
+  // very forward detectors
+  if (Enable::BBC) BbcInit();
+  
+  // tracking
+  if (Enable::TRACKING) TrackingInit();
+
+  // others
+  if (Enable::USER) UserInit();
+  if (Enable::BLACKHOLE) BlackHoleInit();
+  
+  
+}
+
+int G4Setup(TString specialSetting = "")
+{
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4Reco *g4Reco = new PHG4Reco();
+
+  WorldInit(g4Reco);
+
+  g4Reco->set_rapidity_coverage(1.1);  // according to drawings
+                                       // uncomment to set QGSP_BERT_HP physics list for productions
+                                       // (default is QGSP_BERT for speed)
+  //  g4Reco->SetPhysicsList("QGSP_BERT_HP");
+
+  if (G4P6DECAYER::decayType != EDecayType::kAll){
+    g4Reco->set_force_decay(G4P6DECAYER::decayType);
+  }
+
+  double fieldstrength;
+  istringstream stringline(G4MAGNET::magfield);
+  stringline >> fieldstrength;
+  if (stringline.fail())
+  {  // conversion to double fails -> we have a string
+
+    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos){
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
+    } else {
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::kField2D);
+    }
+  } else {
+    g4Reco->set_field(fieldstrength);  // use const soleniodal field
+  }
+  g4Reco->set_field_rescale(G4MAGNET::magfield_rescale);
+
+// the radius is an older protection against overlaps, it is not
+// clear how well this works nowadays but it doesn't hurt either
+  double radius = 0.;
+  if (Enable::PIPE) radius = Pipe(g4Reco, radius);
+  //----------------------------------------
+  // trackers
+  if (Enable::EGEM) EGEMSetup(g4Reco);
+  if (Enable::FGEM) FGEMSetup(g4Reco);
+  if (Enable::FST) FSTSetup(g4Reco, 1.2);
+  if (Enable::ALLSILICON) AllSiliconSetup(g4Reco);
+  if (Enable::BARREL) Barrel(g4Reco, radius);
+  if (Enable::MVTX) radius = Mvtx(g4Reco, radius);
+  if (Enable::TPC) radius = TPC(g4Reco, radius);
+  if (Enable::FTTL) FTTLSetup(g4Reco,specialSetting);
+  if (Enable::ETTL) ETTLSetup(g4Reco,specialSetting);
+  if (Enable::CTTL) CTTLSetup(g4Reco,specialSetting);
+  
+  //----------------------------------------
+  // beam counters
+  if (Enable::BBC) Bbc(g4Reco);
+  //----------------------------------------
+  // calos
+  if (Enable::CEMC) radius = CEmc(g4Reco, radius);
+  if (Enable::HCALIN) radius = HCalInner(g4Reco, radius, 4);
+  if (Enable::MAGNET) radius = Magnet(g4Reco, radius);
+  if (Enable::HCALOUT) radius = HCalOuter(g4Reco, radius, 4);
+  if (Enable::FEMC) FEMCSetup(g4Reco);
+  if (Enable::FHCAL) FHCALSetup(g4Reco);
+  if (Enable::DRCALO) DRCALOSetup(g4Reco);
+  if (Enable::EEMC) EEMCSetup(g4Reco);
+
+  //----------------------------------------
+  // PID
+  if (Enable::DIRC) DIRCSetup(g4Reco);
+  if (Enable::RICH) RICHSetup(g4Reco);
+  if (Enable::AEROGEL) AerogelSetup(g4Reco);
+
+  //----------------------------------------
+  // sPHENIX forward flux return door
+  if (Enable::PLUGDOOR) PlugDoor(g4Reco);
+  if (Enable::USER) UserDetector(g4Reco);
+  
+  //----------------------------------------
+  // BLACKHOLE if enabled, needs info from all previous sub detectors for dimensions
+  if (Enable::BLACKHOLE) BlackHole(g4Reco, radius);
+
+  PHG4TruthSubsystem *truth = new PHG4TruthSubsystem();
+  g4Reco->registerSubsystem(truth);
+  // finally adjust the world size in case the default is too small
+  WorldSize(g4Reco, radius);
+
+  se->registerSubsystem(g4Reco);
+  return 0;
+}
+
+void ShowerCompress()
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4DstCompressReco *compress = new PHG4DstCompressReco("PHG4DstCompressReco");
+  compress->AddHitContainer("G4HIT_PIPE");
+  compress->AddHitContainer("G4HIT_FIELDCAGE");
+  compress->AddHitContainer("G4HIT_CEMC_ELECTRONICS");
+  compress->AddHitContainer("G4HIT_CEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_CEMC");
+  compress->AddHitContainer("G4HIT_CEMC_SPT");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN_SPT");
+  compress->AddHitContainer("G4HIT_MAGNET");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALOUT");
+  compress->AddHitContainer("G4HIT_HCALOUT");
+  compress->AddHitContainer("G4HIT_BH_1");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_PLUS");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_NEG");
+  compress->AddCellContainer("G4CELL_CEMC");
+  compress->AddCellContainer("G4CELL_HCALIN");
+  compress->AddCellContainer("G4CELL_HCALOUT");
+  compress->AddTowerContainer("TOWER_SIM_CEMC");
+  compress->AddTowerContainer("TOWER_RAW_CEMC");
+  compress->AddTowerContainer("TOWER_CALIB_CEMC");
+  compress->AddTowerContainer("TOWER_SIM_HCALIN");
+  compress->AddTowerContainer("TOWER_RAW_HCALIN");
+  compress->AddTowerContainer("TOWER_CALIB_HCALIN");
+  compress->AddTowerContainer("TOWER_SIM_HCALOUT");
+  compress->AddTowerContainer("TOWER_RAW_HCALOUT");
+  compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+
+  compress->AddHitContainer("G4HIT_FEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_FEMC");
+  compress->AddHitContainer("G4HIT_FHCAL");
+  compress->AddHitContainer("G4HIT_DRCALO");
+  compress->AddHitContainer("G4HIT_ABSORBER_FHCAL");
+  compress->AddHitContainer("G4HIT_ABSORBER_DRCALO");
+  compress->AddCellContainer("G4CELL_FEMC");
+  compress->AddCellContainer("G4CELL_FHCAL");
+  compress->AddCellContainer("G4CELL_DRCALO");
+  compress->AddTowerContainer("TOWER_SIM_FEMC");
+  compress->AddTowerContainer("TOWER_RAW_FEMC");
+  compress->AddTowerContainer("TOWER_CALIB_FEMC");
+  compress->AddTowerContainer("TOWER_SIM_FHCAL");
+  compress->AddTowerContainer("TOWER_RAW_FHCAL");
+  compress->AddTowerContainer("TOWER_CALIB_FHCAL");
+  compress->AddTowerContainer("TOWER_SIM_DRCALO");
+  compress->AddTowerContainer("TOWER_RAW_DRCALO");
+  compress->AddTowerContainer("TOWER_CALIB_DRCALO");
+
+  compress->AddHitContainer("G4HIT_EEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_EEMC");
+  compress->AddCellContainer("G4CELL_EEMC");
+  compress->AddTowerContainer("TOWER_SIM_EEMC");
+  compress->AddTowerContainer("TOWER_RAW_EEMC");
+  compress->AddTowerContainer("TOWER_CALIB_EEMC");
+
+  se->registerSubsystem(compress);
+
+  return;
+}
+
+void DstCompress(Fun4AllDstOutputManager *out)
+{
+  if (out)
+  {
+    out->StripNode("G4HIT_PIPE");
+    out->StripNode("G4HIT_SVTXSUPPORT");
+    out->StripNode("G4HIT_CEMC_ELECTRONICS");
+    out->StripNode("G4HIT_CEMC");
+    out->StripNode("G4HIT_ABSORBER_CEMC");
+    out->StripNode("G4HIT_CEMC_SPT");
+    out->StripNode("G4HIT_ABSORBER_HCALIN");
+    out->StripNode("G4HIT_HCALIN");
+    out->StripNode("G4HIT_HCALIN_SPT");
+    out->StripNode("G4HIT_MAGNET");
+    out->StripNode("G4HIT_ABSORBER_HCALOUT");
+    out->StripNode("G4HIT_HCALOUT");
+    out->StripNode("G4HIT_BH_1");
+    out->StripNode("G4HIT_BH_FORWARD_PLUS");
+    out->StripNode("G4HIT_BH_FORWARD_NEG");
+    out->StripNode("G4CELL_CEMC");
+    out->StripNode("G4CELL_HCALIN");
+    out->StripNode("G4CELL_HCALOUT");
+
+    out->StripNode("G4HIT_FEMC");
+    out->StripNode("G4HIT_ABSORBER_FEMC");
+    out->StripNode("G4HIT_FHCAL");
+    out->StripNode("G4HIT_DRCALO");
+    out->StripNode("G4HIT_ABSORBER_FHCAL");
+    out->StripNode("G4HIT_ABSORBER_DRCALO");
+    out->StripNode("G4CELL_FEMC");
+    out->StripNode("G4CELL_FHCAL");
+    out->StripNode("G4CELL_DRCALO");
+
+    out->StripNode("G4HIT_EEMC");
+    out->StripNode("G4HIT_ABSORBER_EEMC");
+    out->StripNode("G4CELL_EEMC");
+  }
+}
+#endif

--- a/detectors/DualReadout/init_gui_vis.mac
+++ b/detectors/DualReadout/init_gui_vis.mac
@@ -1,0 +1,20 @@
+# Macro file for the initialization of example B3
+# in interactive session
+#
+# Set some default verbose
+#
+/control/verbose 2
+/control/saveHistory
+/run/verbose 2
+#
+# Change the default number of threads (in multi-threaded mode)
+#/run/numberOfThreads 4
+#
+# Initialize kernel
+/run/initialize
+#
+# create empty scene
+#
+/vis/scene/create
+# open graphics (opengl QT)
+/vis/open OGL

--- a/detectors/DualReadout/vis.mac
+++ b/detectors/DualReadout/vis.mac
@@ -1,0 +1,87 @@
+# $Id: vis.mac,v 1.4 2010/04/14 18:32:59 lindenle Exp $
+#
+# Macro file for the initialization phase of "exampleN03.cc"
+# when running in interactive mode
+#
+# Sets some default verbose
+#
+/control/verbose 2
+/control/saveHistory
+/run/verbose 2
+#
+# create empty scene
+#
+/vis/scene/create
+#
+# Create a scene handler for a specific graphics system
+# (Edit the next line(s) to choose another graphic system)
+#
+# Use this open statement to get an .eps and .prim files
+# suitable for viewing in DAWN.
+###/vis/open DAWNFILE
+#
+# Use this open statement instead for OpenGL in immediate mode.
+# OGLIX works on the desktops in 1008 while OGLSX terminates
+# the X server. I've heard similar stories about OGLIX on other
+# machines. You might have to play with it. GEANT prints out a
+# list of available graphics systems at some point.
+#/vis/open OGLIX
+/vis/open OGL 1200x900-0+0
+/vis/viewer/set/lineSegmentsPerCircle 10
+#/vis/viewer/set/style cloud
+# increase display limit for more complex detectors
+/vis/ogl/set/displayListLimit 500000
+/vis/viewer/set/viewpointThetaPhi 260 -40
+/vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
+/vis/viewer/addCutawayPlane 0 0 0 m 0 -1 0
+# /vis/viewer/panTo 150 0 cm
+
+# our world is 4x4 meters, the detector is about 1m across
+# zooming by 4 makes it fill the display
+/vis/viewer/zoom 1.8
+#
+# Use this open statement instead to get a HepRep version 1 file
+# suitable for viewing in WIRED.
+#/vis/open HepRepFile
+#
+# Use this open statement instead to get a HepRep version 2 file
+# suitable for viewing in WIRED.
+#/vis/open HepRepXML
+#
+# Output an empty detector
+/vis/viewer/flush
+#
+# Draw trajectories at end of event, showing trajectory points as
+# markers of size 2 pixels
+/vis/scene/add/trajectories smooth rich
+/vis/modeling/trajectories/create/drawByCharge
+/vis/modeling/trajectories/drawByCharge-0/default/setDrawStepPts true
+/vis/modeling/trajectories/drawByCharge-0/default/setStepPtsSize 2
+# (if too many tracks cause core dump => /tracking/storeTrajectory 0)
+#
+# To draw gammas only
+#/vis/filtering/trajectories/create/particleFilter
+#/vis/filtering/trajectories/particleFilter-0/add gamma
+#
+# To draw charged particles only
+#/vis/filtering/trajectories/particleFilter-0/invert true
+#
+# Many other options available with /vis/modeling and /vis/filtering.
+# For example, select colour by particle ID
+#/vis/modeling/trajectories/create/drawByParticleID
+#/vis/modeling/trajectories/drawByParticleID-0/set e- red
+# remove low energy stuff
+/vis/filtering/trajectories/create/attributeFilter
+/vis/filtering/trajectories/attributeFilter-0/setAttribute IMag
+/vis/filtering/trajectories/attributeFilter-0/addInterval 10 MeV 1000 GeV
+#
+/vis/scene/endOfEventAction accumulate
+#
+# At end of each run, an automatic flush causes graphical output.
+#/run/beamOn 1
+# When you exit Geant4, you will find a file called scene-0.heprep.zip.
+# Unzipping this will give you three separate HepRep files suitable for
+# viewing in WIRED.
+# The first file will contain just detector geometry.
+# The second file will contain the detector plus one event.
+# The third file will contain the detector plus ten events.

--- a/detectors/EICDetector/DisplayOn.C
+++ b/detectors/EICDetector/DisplayOn.C
@@ -1,0 +1,64 @@
+#ifndef MACRO_DISPLAYON_C
+#define MACRO_DISPLAYON_C
+
+#include <g4main/PHG4Reco.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libg4testbench.so)
+
+namespace Enable
+{
+  bool DISPLAY = false;
+}
+
+// This starts the QT based G4 gui which takes control
+// when x'ed out it will return a pointer to PHG4Reco so
+// the gui can be startrd again
+PHG4Reco *QTGui()
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
+  g4->StartGui();
+  return g4;
+}
+
+// stupid macro to turn on the geant4 display
+// we ask Fun4All for a pointer to PHG4Reco
+// using the ApplyCommand will start up the
+// G4 cmd interpreter and graphics system
+// the vis.mac contains the necessary commands to
+// start up the visualization, the next event will
+// be displayed. Do not execute this macro
+// before PHG4Reco was registered with Fun4All
+PHG4Reco * DisplayOn(const char *mac = "vis.mac")
+{
+  char cmd[100];
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
+  sprintf(cmd, "/control/execute %s", mac);
+  g4->ApplyCommand(cmd);
+  return g4;
+}
+// print out the commands I always forget
+void displaycmd()
+{
+  cout << "draw axis: " << endl;
+  cout << " g4->ApplyCommand(\"/vis/scene/add/axes 0 0 0 50 cm\")" << endl;
+  cout << "zoom" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/zoom 1\")" << endl;
+  cout << "viewpoint:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/set/viewpointThetaPhi 0 0\")" << endl;
+  cout << "panTo:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/panTo 0 0 cm\")" << endl;
+  cout << "print to eps:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/ogl/printEPS\")" << endl;
+  cout << "set background color:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/set/background white\")" << endl;
+}
+#endif

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -1,0 +1,574 @@
+#ifndef MACRO_FUN4ALLG4EICDETECTOR_C
+#define MACRO_FUN4ALLG4EICDETECTOR_C
+
+#include <GlobalVariables.C>
+
+#include <DisplayOn.C>
+#include <G4Setup_EICDetector.C>
+#include <G4_Bbc.C>
+#include <G4_CaloTrigger.C>
+#include <G4_DSTReader_EICDetector.C>
+#include <G4_FwdJets.C>
+#include <G4_Global.C>
+#include <G4_HIJetReco.C>
+#include <G4_Input.C>
+#include <G4_Jets.C>
+#include <G4_Production.C>
+#include <G4_User.C>
+
+#include <TROOT.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <phool/recoConsts.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+
+int Fun4All_G4_EICDetector(
+    const int nEvents = 1,
+    const string &inputFile = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
+    const string &outputFile = "G4EICDetector.root",
+    const string &embed_input_file = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
+    const int skip = 0,
+    const string &outdir = ".")
+{
+  //---------------
+  // Fun4All server
+  //---------------
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->Verbosity(0);
+  //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
+  //PHRandomSeed::Verbosity(1);
+
+  // just if we set some flags somewhere in this macro
+  recoConsts *rc = recoConsts::instance();
+  // By default every random number generator uses
+  // PHRandomSeed() which reads /dev/urandom to get its seed
+  // if the RANDOMSEED flag is set its value is taken as initial seed
+  // which will produce identical results so you can debug your code
+  // rc->set_IntFlag("RANDOMSEED", 12345);
+
+  //===============
+  // Input options
+  //===============
+
+  // Either:
+  // read previously generated g4-hits files, in this case it opens a DST and skips
+  // the simulations step completely. The G4Setup macro is only loaded to get information
+  // about the number of layers used for the cell reco code
+  //
+  //Input::READHITS = true;
+  INPUTREADHITS::filename[0] = inputFile;
+  // if you use a filelist
+  // INPUTREADHITS::listfile[0] = inputFile;
+
+  // Or:
+  // Use one or more particle generators
+  // It is run if Input::<generator> is set to true
+  // all other options only play a role if it is active
+  // In case embedding into a production output, please double check your G4Setup_EICDetector.C and G4_*.C consistent with those in the production macro folder
+  //  Input::EMBED = true;
+  INPUTEMBED::filename[0] = embed_input_file;
+  // if you use a filelist
+  //INPUTEMBED::listfile[0] = embed_input_file;
+
+  // Use Pythia 8
+  //  Input::PYTHIA8 = true;
+
+  // Use Pythia 6
+    Input::PYTHIA6 = true;
+
+  // Use Sartre
+  //   Input::SARTRE = true;
+
+  // Simple multi particle generator in eta/phi/pt ranges
+//   Input::SIMPLE = true;
+  // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
+  // Input::SIMPLE_VERBOSITY = 1;
+
+  // Particle gun (same particles in always the same direction)
+  // Input::GUN = true;
+  // Input::GUN_NUMBER = 3; // if you need 3 of them
+  // Input::GUN_VERBOSITY = 0;
+
+  // Upsilon generator
+  // Input::UPSILON = true;
+  // Input::UPSILON_NUMBER = 3; // if you need 3 of them
+  // Input::UPSILON_VERBOSITY = 0;
+
+  // And/Or read generated particles from file
+
+  // eic-smear output
+  //  Input::READEIC = true;
+  INPUTREADEIC::filename = inputFile;
+
+  // HepMC2 files
+  //  Input::HEPMC = true;
+  Input::VERBOSITY = 0;
+  INPUTHEPMC::filename = inputFile;
+
+  //-----------------
+  // Initialize the selected Input/Event generation
+  //-----------------
+  InputInit();
+  //--------------
+  // Set generator specific options
+  //--------------
+  // can only be set after InputInit() is called
+
+  // Simple Input generator:
+  // if you run more than one of these Input::SIMPLE_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
+  if (Input::SIMPLE)
+  {
+    INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi-", 5);
+    if (Input::HEPMC || Input::EMBED)
+    {
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+    }
+    else
+    {
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
+                                                                                PHG4SimpleEventGenerator::Uniform,
+                                                                                PHG4SimpleEventGenerator::Uniform);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
+    }
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-3, 3);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(0.1, 20.);
+  }
+  // Upsilons
+  // if you run more than one of these Input::UPSILON_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
+  if (Input::UPSILON)
+  {
+    INPUTGENERATOR::VectorMesonGenerator[0]->add_decay_particles("mu", 0);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_rapidity_range(-1, 1);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
+    // Y species - select only one, last one wins
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
+    if (Input::HEPMC || Input::EMBED)
+    {
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+    }
+  }
+  // particle gun
+  // if you run more than one of these Input::GUN_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
+  if (Input::GUN)
+  {
+    INPUTGENERATOR::Gun[0]->AddParticle("pi-", 0, 1, 0);
+    INPUTGENERATOR::Gun[0]->set_vtx(0, 0, 0);
+  }
+  // pythia6
+  if (Input::PYTHIA6)
+  {
+    INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep.cfg");
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::Pythia6);
+  }
+  // pythia8
+  if (Input::PYTHIA8)
+  {
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::Pythia8);
+  }
+  // Sartre
+  if (Input::SARTRE)
+  {
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::Sartre);
+  }
+
+  //--------------
+  // Set Input Manager specific options
+  //--------------
+  // can only be set after InputInit() is called
+
+  if (Input::HEPMC)
+  {
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTMANAGER::HepMCInputManager);
+    // optional overriding beam parameters
+    //INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 30, 0);  //optional collision smear in space, time
+                                                                                            //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
+    // //optional choice of vertex distribution function in space, time
+    // INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
+    //! embedding ID for the event
+    //! positive ID is the embedded event of interest, e.g. jetty event from pythia
+    //! negative IDs are backgrounds, .e.g out of time pile up collisions
+    //! Usually, ID = 0 means the primary Au+Au collision background
+    //INPUTMANAGER::HepMCInputManager->set_embedding_id(2);
+  }
+
+  // register all input generators with Fun4All
+  InputRegister();
+
+  // Reads event generators in EIC smear files, which is registered in InputRegister
+  if (Input::READEIC)
+  {
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::EICFileReader);
+  }
+
+  // set up production relatedstuff
+  //   Enable::PRODUCTION = true;
+
+  //======================
+  // Write the DST
+  //======================
+
+  Enable::DSTOUT = false;
+  DstOut::OutputDir = outdir;
+  DstOut::OutputFile = outputFile;
+  Enable::DSTOUT_COMPRESS = false;  // Compress DST files
+
+  //Option to convert DST to human command readable TTree for quick poke around the outputs
+//  Enable::DSTREADER = true;
+
+  // turn the display on (default off)
+  Enable::DISPLAY = false;
+
+  //======================
+  // What to run
+  //======================
+  // Global options (enabled for all subsystems - if implemented)
+  //  Enable::ABSORBER = true;
+  //  Enable::OVERLAPCHECK = true;
+  //  Enable::VERBOSITY = 1;
+
+  //  Enable::BBC = true;
+  Enable::BBCFAKE = true; // Smeared vtx and t0, use if you don't want real BBC in simulation
+
+  // whether to simulate the Be section of the beam pipe
+  Enable::PIPE = true;
+  // EIC beam pipe extension beyond the Be-section:
+  G4PIPE::use_forward_pipes = false;
+  //EIC hadron far forward magnets and detectors. IP6 and IP8 are incompatible (pick either or);
+  Enable::HFARFWD_MAGNETS_IP6=true;
+  Enable::HFARFWD_VIRTUAL_DETECTORS_IP6=true;
+  Enable::HFARFWD_MAGNETS_IP8=false;
+  Enable::HFARFWD_VIRTUAL_DETECTORS_IP8=false;
+
+  // gems
+  Enable::EGEM = true;
+  Enable::FGEM = true;
+  Enable::FGEM_ORIG = false; //5 forward gems; cannot be used with FST
+  // barrel tracker
+  Enable::BARREL = false;
+  //G4BARREL::SETTING::BARRELV6=true;
+  // fst
+  Enable::FST = true;
+  G4FST::SETTING::FST_TPC = true;
+  // mvtx/tpc tracker
+  Enable::MVTX = true;
+  Enable::TPC = true;
+  //  Enable::TPC_ENDCAP = true;
+
+  Enable::TRACKING = true;
+  Enable::TRACKING_EVAL = Enable::TRACKING && true;
+  G4TRACKING::DISPLACED_VERTEX = true;  // this option exclude vertex in the track fitting and use RAVE to reconstruct primary and 2ndary vertexes
+                                         // projections to calorimeters
+  G4TRACKING::PROJECTION_EEMC = false;
+  G4TRACKING::PROJECTION_CEMC = false;
+  G4TRACKING::PROJECTION_FEMC = false;
+  G4TRACKING::PROJECTION_FHCAL = false;
+
+  Enable::CEMC = true;
+  //  Enable::CEMC_ABSORBER = true;
+  Enable::CEMC_CELL = Enable::CEMC && true;
+  Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
+  Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
+  Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
+
+  Enable::HCALIN = true;
+  //  Enable::HCALIN_ABSORBER = true;
+  Enable::HCALIN_CELL = Enable::HCALIN && true;
+  Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
+  Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
+  Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && true;
+
+  Enable::MAGNET = true;
+
+  Enable::HCALOUT = true;
+  //  Enable::HCALOUT_ABSORBER = true;
+  Enable::HCALOUT_CELL = Enable::HCALOUT && true;
+  Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
+  Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
+  Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && true;
+
+  // EICDetector geometry - barrel
+  Enable::DIRC = true;
+
+  // EICDetector geometry - 'hadron' direction
+  Enable::RICH = true;
+  Enable::AEROGEL = true;
+
+  Enable::FEMC = true;
+  //  Enable::FEMC_ABSORBER = true;
+  Enable::FEMC_TOWER = Enable::FEMC && true;
+  Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
+  Enable::FEMC_EVAL = Enable::FEMC_CLUSTER && true;
+
+  Enable::FHCAL = true;
+  //  Enable::FHCAL_ABSORBER = true;
+  Enable::FHCAL_TOWER = Enable::FHCAL && true;
+  Enable::FHCAL_CLUSTER = Enable::FHCAL_TOWER && true;
+  Enable::FHCAL_EVAL = Enable::FHCAL_CLUSTER && true;
+
+  // EICDetector geometry - 'electron' direction
+  Enable::EEMC = true;
+  Enable::EEMC_TOWER = Enable::EEMC && true;
+  Enable::EEMC_CLUSTER = Enable::EEMC_TOWER && true;
+  Enable::EEMC_EVAL = Enable::EEMC_CLUSTER && true;
+
+  Enable::PLUGDOOR = true;
+
+  // Other options
+  Enable::GLOBAL_RECO = true;
+  Enable::GLOBAL_FASTSIM = true;
+
+  Enable::CALOTRIGGER = true && Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER;
+
+  // Select only one jet reconstruction- they currently use the same
+  // output collections on the node tree!
+  Enable::JETS = true;
+  Enable::JETS_EVAL = Enable::JETS && true;
+
+  Enable::FWDJETS = true;
+  Enable::FWDJETS_EVAL = Enable::FWDJETS && true;
+
+  // HI Jet Reco for jet simulations in Au+Au (default is false for
+  // single particle / p+p simulations, or for Au+Au simulations which
+  // don't care about jets)
+  Enable::HIJETS = false && Enable::JETS && Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER;
+
+  // new settings using Enable namespace in GlobalVariables.C
+  Enable::BLACKHOLE = true;
+  //Enable::BLACKHOLE_SAVEHITS = false; // turn off saving of bh hits
+  //BlackHoleGeometry::visible = true;
+
+  //Enable::USER = true;
+
+  //---------------
+  // World Settings
+  //---------------
+  //  G4WORLD::PhysicsList = "FTFP_BERT"; //FTFP_BERT_HP best for calo
+  //  G4WORLD::WorldMaterial = "G4_AIR"; // set to G4_GALACTIC for material scans
+
+  //---------------
+  // Magnet Settings
+  //---------------
+
+  //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+  //  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // default map from the calibration database
+  G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
+
+  //---------------
+  // Pythia Decayer
+  //---------------
+  // list of decay types in
+  // $OFFLINE_MAIN/include/g4decayer/EDecayType.hh
+  // default is All:
+  // G4P6DECAYER::decayType = EDecayType::kAll;
+
+  // Initialize the selected subsystems
+  G4Init();
+
+  //---------------------
+  // GEANT4 Detector description
+  //---------------------
+
+  // If "readhepMC" is also set, the Upsilons will be embedded in Hijing events, if 'particles" is set, the Upsilons will be embedded in whatever particles are thrown
+  if (!Input::READHITS)
+  {
+    G4Setup();
+  }
+
+  //------------------
+  // Detector Division
+  //------------------
+
+  if (Enable::BBC || Enable::BBCFAKE) Bbc_Reco();
+
+  if (Enable::CEMC_CELL) CEMC_Cells();
+
+  if (Enable::HCALIN_CELL) HCALInner_Cells();
+
+  if (Enable::HCALOUT_CELL) HCALOuter_Cells();
+
+  //-----------------------------
+  // CEMC towering and clustering
+  //-----------------------------
+
+  if (Enable::CEMC_TOWER) CEMC_Towers();
+  if (Enable::CEMC_CLUSTER) CEMC_Clusters();
+
+  //-----------------------------
+  // HCAL towering and clustering
+  //-----------------------------
+
+  if (Enable::HCALIN_TOWER) HCALInner_Towers();
+  if (Enable::HCALIN_CLUSTER) HCALInner_Clusters();
+
+  if (Enable::HCALOUT_TOWER) HCALOuter_Towers();
+  if (Enable::HCALOUT_CLUSTER) HCALOuter_Clusters();
+
+  //-----------------------------
+  // e, h direction Calorimeter  towering and clustering
+  //-----------------------------
+
+  if (Enable::FEMC_TOWER) FEMC_Towers();
+  if (Enable::FEMC_CLUSTER) FEMC_Clusters();
+
+  if (Enable::FHCAL_TOWER) FHCAL_Towers();
+  if (Enable::FHCAL_CLUSTER) FHCAL_Clusters();
+
+  if (Enable::EEMC_TOWER) EEMC_Towers();
+  if (Enable::EEMC_CLUSTER) EEMC_Clusters();
+
+  if (Enable::DSTOUT_COMPRESS) ShowerCompress();
+
+  //--------------
+  // SVTX tracking
+  //--------------
+
+  if (Enable::TRACKING) Tracking_Reco();
+
+  //-----------------
+  // Global Vertexing
+  //-----------------
+
+  if (Enable::GLOBAL_RECO)
+  {
+    Global_Reco();
+  }
+  else if (Enable::GLOBAL_FASTSIM)
+  {
+    Global_FastSim();
+  }
+
+  //-----------------
+  // Calo Trigger Simulation
+  //-----------------
+
+  if (Enable::CALOTRIGGER) CaloTrigger_Sim();
+
+  //---------
+  // Jet reco
+  //---------
+
+  if (Enable::JETS) Jet_Reco();
+
+  if (Enable::HIJETS) HIJetReco();
+
+  if (Enable::FWDJETS) Jet_FwdReco();
+
+  string outputroot = outputFile;
+  string remove_this = ".root";
+  size_t pos = outputroot.find(remove_this);
+  if (pos != string::npos)
+  {
+    outputroot.erase(pos, remove_this.length());
+  }
+
+  if (Enable::DSTREADER) G4DSTreader_EICDetector(outputroot + "_DSTReader.root");
+
+  //----------------------
+  // Simulation evaluation
+  //----------------------
+  if (Enable::TRACKING_EVAL) Tracking_Eval(outputroot + "_g4tracking_eval.root");
+
+  if (Enable::CEMC_EVAL) CEMC_Eval(outputroot + "_g4cemc_eval.root");
+
+  if (Enable::HCALIN_EVAL) HCALInner_Eval(outputroot + "_g4hcalin_eval.root");
+
+  if (Enable::HCALOUT_EVAL) HCALOuter_Eval(outputroot + "_g4hcalout_eval.root");
+
+  if (Enable::FEMC_EVAL) FEMC_Eval(outputroot + "_g4femc_eval.root");
+
+  if (Enable::FHCAL_EVAL) FHCAL_Eval(outputroot + "_g4fhcal_eval.root");
+
+  if (Enable::EEMC_EVAL) EEMC_Eval(outputroot + "_g4eemc_eval.root");
+
+  if (Enable::JETS_EVAL) Jet_Eval(outputroot + "_g4jet_eval.root");
+
+  if (Enable::FWDJETS_EVAL) Jet_FwdEval(outputroot + "_g4fwdjet_eval.root");
+
+  if (Enable::USER) UserAnalysisInit();
+
+  //--------------
+  // Set up Input Managers
+  //--------------
+
+  InputManagers();
+
+  //--------------
+  // Set up Output Manager
+  //--------------
+  if (Enable::PRODUCTION)
+  {
+    Production_CreateOutputDir();
+  }
+
+  if (Enable::DSTOUT)
+  {
+    string FullOutFile = DstOut::OutputDir + "/" + DstOut::OutputFile;
+    Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", FullOutFile);
+    if (Enable::DSTOUT_COMPRESS) DstCompress(out);
+    se->registerOutputManager(out);
+  }
+
+  //-----------------
+  // Event processing
+  //-----------------
+  if (Enable::DISPLAY)
+  {
+    DisplayOn();
+
+    gROOT->ProcessLine("Fun4AllServer *se = Fun4AllServer::instance();");
+    gROOT->ProcessLine("PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");");
+
+    cout << "-------------------------------------------------" << endl;
+    cout << "You are in event display mode. Run one event with" << endl;
+    cout << "se->run(1)" << endl;
+    cout << "Run Geant4 command with following examples" << endl;
+    gROOT->ProcessLine("displaycmd()");
+
+    return 0;
+  }
+  // if we use a negative number of events we go back to the command line here
+  if (nEvents < 0)
+  {
+    return 0;
+  }
+  // if we run any of the particle generators and use 0 it'll run forever
+  if (nEvents == 0 && !Input::READHITS && !Input::HEPMC && !Input::READEIC)
+  {
+    cout << "using 0 for number of events is a bad idea when using particle generators" << endl;
+    cout << "it will run forever, so I just return without running anything" << endl;
+    return 0;
+  }
+
+  se->skip(skip);
+  se->run(nEvents);
+
+  //-----
+  // Exit
+  //-----
+
+  se->End();
+  std::cout << "All done" << std::endl;
+  delete se;
+  if (Enable::PRODUCTION)
+  {
+    Production_MoveOutput();
+  }
+  gSystem->Exit(0);
+  return 0;
+}
+#endif

--- a/detectors/EICDetector/G4Setup_EICDetector.C
+++ b/detectors/EICDetector/G4Setup_EICDetector.C
@@ -1,0 +1,296 @@
+#ifndef MACRO_G4SETUPEICDETECTOR_C
+#define MACRO_G4SETUPEICDETECTOR_C
+
+#include <GlobalVariables.C>
+
+#include <G4_Aerogel.C>
+#include <G4_Barrel_EIC.C>
+#include <G4_Bbc.C>
+#include <G4_BlackHole.C>
+#include <G4_CEmc_EIC.C>
+#include <G4_DIRC.C>
+#include <G4_EEMC.C>
+#include <G4_FEMC_EIC.C>
+#include <G4_FHCAL.C>
+#include <G4_FST_EIC.C>
+#include <G4_GEM_EIC.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Input.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx_EIC.C>
+#include <G4_Pipe_EIC.C>
+#include <G4_PlugDoor_EIC.C>
+#include <G4_RICH.C>
+#include <G4_TPC_EIC.C>
+#include <G4_Tracking_EIC.C>
+#include <G4_User.C>
+#include <G4_World.C>
+#include <G4_hFarFwdBeamLine_EIC.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4eval/PHG4DstCompressReco.h>
+
+#include <g4main/PHG4Reco.h>
+#include <g4main/PHG4TruthSubsystem.h>
+
+#include <phfield/PHFieldConfig.h>
+
+#include <g4decayer/EDecayType.hh>
+
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libg4decayer.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+
+void G4Init()
+{
+  // First some check for subsystems which do not go together
+
+  if (Enable::TPC && Enable::FST && !G4FST::SETTING::FST_TPC)
+  {
+    cout << "FST setup cannot fit in the TPC" << endl;
+    gSystem->Exit(1);
+  }
+  else if (Enable::MVTX && Enable::BARREL)
+  {
+    cout << "MVTX and BARREL cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  }
+  else if (Enable::TPC && Enable::BARREL && !G4BARREL::SETTING::BARRELV6) {
+    cout << "Barrel setup cannot fit in the TPC" << endl;
+    gSystem->Exit(1);
+  }
+
+  if(Enable::FGEM_ORIG && Enable::FST)
+  {
+    cout << "FST cannot be enabled with 5 FGEM setup" << endl;
+    gSystem->Exit(1);
+  }
+
+  if(Enable::FGEM_ORIG && Enable::FST)
+  {
+    cout << "FST cannot be enabled with 5 FGEM setup" << endl;
+    gSystem->Exit(1);
+  }
+
+  // load detector/material macros and execute Init() function
+  if (Enable::PIPE) PipeInit();
+  if (Enable::HFARFWD_MAGNETS_IP6 || Enable::HFARFWD_MAGNETS_IP8) hFarFwdBeamLineInit();
+  if (Enable::PLUGDOOR) PlugDoorInit();
+  if (Enable::EGEM) EGEM_Init();
+  if (Enable::FGEM || Enable::FGEM_ORIG) FGEM_Init();
+  if (Enable::FST) FST_Init();
+  if (Enable::BARREL) BarrelInit();
+  if (Enable::MVTX) MvtxInit();
+  if (Enable::TPC) TPCInit();
+  if (Enable::TRACKING) TrackingInit();
+  if (Enable::BBC) BbcInit();
+  if (Enable::CEMC) CEmcInit(72);  // make it 2*2*2*3*3 so we can try other combinations
+  if (Enable::HCALIN) HCalInnerInit(1);
+  if (Enable::MAGNET) MagnetInit();
+  MagnetFieldInit(); // We want the field - even if the magnet volume is disabled
+  if (Enable::HCALOUT) HCalOuterInit();
+  if (Enable::FEMC) FEMCInit();
+  if (Enable::FHCAL) FHCALInit();
+  if (Enable::EEMC) EEMCInit();
+  if (Enable::DIRC) DIRCInit();
+  if (Enable::RICH) RICHInit();
+  if (Enable::AEROGEL) AerogelInit();
+  if (Enable::USER) UserInit();
+  if (Enable::BLACKHOLE) BlackHoleInit();
+}
+
+int G4Setup()
+{
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4Reco *g4Reco = new PHG4Reco();
+
+  WorldInit(g4Reco);
+
+  g4Reco->set_rapidity_coverage(1.1);  // according to drawings
+                                       // uncomment to set QGSP_BERT_HP physics list for productions
+                                       // (default is QGSP_BERT for speed)
+  //  g4Reco->SetPhysicsList("QGSP_BERT_HP");
+
+  if (G4P6DECAYER::decayType != EDecayType::kAll)
+  {
+    g4Reco->set_force_decay(G4P6DECAYER::decayType);
+  }
+
+  double fieldstrength;
+  istringstream stringline(G4MAGNET::magfield);
+  stringline >> fieldstrength;
+  if (stringline.fail())
+  {  // conversion to double fails -> we have a string
+
+    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos)
+    {
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
+    }
+    else
+    {
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::kField2D);
+    }
+  }
+  else
+  {
+    g4Reco->set_field(fieldstrength);  // use const soleniodal field
+  }
+  g4Reco->set_field_rescale(G4MAGNET::magfield_rescale);
+
+// the radius is an older protection against overlaps, it is not
+// clear how well this works nowadays but it doesn't hurt either
+  double radius = 0.;
+
+  if (Enable::PIPE) radius = Pipe(g4Reco, radius);
+  if (Enable::HFARFWD_MAGNETS_IP6 || Enable::HFARFWD_MAGNETS_IP8) hFarFwdDefineMagnets(g4Reco);
+  if (Enable::HFARFWD_VIRTUAL_DETECTORS_IP6 || Enable::HFARFWD_VIRTUAL_DETECTORS_IP8) hFarFwdDefineDetectors(g4Reco);
+  if (Enable::EGEM) EGEMSetup(g4Reco);
+  if (Enable::FGEM || Enable::FGEM_ORIG) FGEMSetup(g4Reco);
+  if (Enable::FST) FSTSetup(g4Reco);
+  if (Enable::BARREL) Barrel(g4Reco, radius);
+  if (Enable::MVTX) radius = Mvtx(g4Reco, radius);
+  if (Enable::TPC) radius = TPC(g4Reco, radius);
+  if (Enable::BBC) Bbc(g4Reco);
+  if (Enable::CEMC) radius = CEmc(g4Reco, radius);
+  if (Enable::HCALIN) radius = HCalInner(g4Reco, radius, 4);
+  if (Enable::MAGNET) radius = Magnet(g4Reco, radius);
+  if (Enable::HCALOUT) radius = HCalOuter(g4Reco, radius, 4);
+  if (Enable::FEMC) FEMCSetup(g4Reco);
+  if (Enable::FHCAL) FHCALSetup(g4Reco);
+  if (Enable::EEMC) EEMCSetup(g4Reco);
+
+  //----------------------------------------
+  // PID
+
+  if (Enable::DIRC) DIRCSetup(g4Reco);
+  if (Enable::RICH) RICHSetup(g4Reco);
+  if (Enable::AEROGEL) AerogelSetup(g4Reco);
+
+  //----------------------------------------
+  // sPHENIX forward flux return door
+  if (Enable::PLUGDOOR) PlugDoor(g4Reco);
+
+  if (Enable::USER) UserDetector(g4Reco);
+  
+  //----------------------------------------
+  // BLACKHOLE if enabled, needs info from all previous sub detectors for dimensions
+  if (Enable::BLACKHOLE) BlackHole(g4Reco, radius);
+
+  PHG4TruthSubsystem *truth = new PHG4TruthSubsystem();
+  g4Reco->registerSubsystem(truth);
+  // finally adjust the world size in case the default is too small
+  WorldSize(g4Reco, radius);
+
+  se->registerSubsystem(g4Reco);
+  return 0;
+}
+
+void ShowerCompress()
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4DstCompressReco *compress = new PHG4DstCompressReco("PHG4DstCompressReco");
+  compress->AddHitContainer("G4HIT_PIPE");
+  compress->AddHitContainer("G4HIT_ZDC");
+  compress->AddHitContainer("G4HIT_RomanPots");
+  compress->AddHitContainer("G4HIT_B0detector");
+  compress->AddHitContainer("G4HIT_FIELDCAGE");
+  compress->AddHitContainer("G4HIT_CEMC_ELECTRONICS");
+  compress->AddHitContainer("G4HIT_CEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_CEMC");
+  compress->AddHitContainer("G4HIT_CEMC_SPT");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN_SPT");
+  compress->AddHitContainer("G4HIT_MAGNET");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALOUT");
+  compress->AddHitContainer("G4HIT_HCALOUT");
+  compress->AddHitContainer("G4HIT_BH_1");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_PLUS");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_NEG");
+  compress->AddCellContainer("G4CELL_CEMC");
+  compress->AddCellContainer("G4CELL_HCALIN");
+  compress->AddCellContainer("G4CELL_HCALOUT");
+  compress->AddTowerContainer("TOWER_SIM_CEMC");
+  compress->AddTowerContainer("TOWER_RAW_CEMC");
+  compress->AddTowerContainer("TOWER_CALIB_CEMC");
+  compress->AddTowerContainer("TOWER_SIM_HCALIN");
+  compress->AddTowerContainer("TOWER_RAW_HCALIN");
+  compress->AddTowerContainer("TOWER_CALIB_HCALIN");
+  compress->AddTowerContainer("TOWER_SIM_HCALOUT");
+  compress->AddTowerContainer("TOWER_RAW_HCALOUT");
+  compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+
+  compress->AddHitContainer("G4HIT_FEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_FEMC");
+  compress->AddHitContainer("G4HIT_FHCAL");
+  compress->AddHitContainer("G4HIT_ABSORBER_FHCAL");
+  compress->AddCellContainer("G4CELL_FEMC");
+  compress->AddCellContainer("G4CELL_FHCAL");
+  compress->AddTowerContainer("TOWER_SIM_FEMC");
+  compress->AddTowerContainer("TOWER_RAW_FEMC");
+  compress->AddTowerContainer("TOWER_CALIB_FEMC");
+  compress->AddTowerContainer("TOWER_SIM_FHCAL");
+  compress->AddTowerContainer("TOWER_RAW_FHCAL");
+  compress->AddTowerContainer("TOWER_CALIB_FHCAL");
+
+  compress->AddHitContainer("G4HIT_EEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_EEMC");
+  compress->AddCellContainer("G4CELL_EEMC");
+  compress->AddTowerContainer("TOWER_SIM_EEMC");
+  compress->AddTowerContainer("TOWER_RAW_EEMC");
+  compress->AddTowerContainer("TOWER_CALIB_EEMC");
+
+  se->registerSubsystem(compress);
+
+  return;
+}
+
+void DstCompress(Fun4AllDstOutputManager *out)
+{
+  if (out)
+  {
+    out->StripNode("G4HIT_PIPE");
+    out->StripNode("G4HIT_ZDC");
+    out->StripNode("G4HIT_RomanPots");
+    out->StripNode("G4HIT_B0detectors");
+    out->StripNode("G4HIT_SVTXSUPPORT");
+    out->StripNode("G4HIT_CEMC_ELECTRONICS");
+    out->StripNode("G4HIT_CEMC");
+    out->StripNode("G4HIT_ABSORBER_CEMC");
+    out->StripNode("G4HIT_CEMC_SPT");
+    out->StripNode("G4HIT_ABSORBER_HCALIN");
+    out->StripNode("G4HIT_HCALIN");
+    out->StripNode("G4HIT_HCALIN_SPT");
+    out->StripNode("G4HIT_MAGNET");
+    out->StripNode("G4HIT_ABSORBER_HCALOUT");
+    out->StripNode("G4HIT_HCALOUT");
+    out->StripNode("G4HIT_BH_1");
+    out->StripNode("G4HIT_BH_FORWARD_PLUS");
+    out->StripNode("G4HIT_BH_FORWARD_NEG");
+    out->StripNode("G4CELL_CEMC");
+    out->StripNode("G4CELL_HCALIN");
+    out->StripNode("G4CELL_HCALOUT");
+
+    out->StripNode("G4HIT_FEMC");
+    out->StripNode("G4HIT_ABSORBER_FEMC");
+    out->StripNode("G4HIT_FHCAL");
+    out->StripNode("G4HIT_ABSORBER_FHCAL");
+    out->StripNode("G4CELL_FEMC");
+    out->StripNode("G4CELL_FHCAL");
+
+    out->StripNode("G4HIT_EEMC");
+    out->StripNode("G4HIT_ABSORBER_EEMC");
+    out->StripNode("G4CELL_EEMC");
+  }
+}
+#endif

--- a/detectors/EICDetector/init_gui_vis.mac
+++ b/detectors/EICDetector/init_gui_vis.mac
@@ -1,0 +1,20 @@
+# Macro file for the initialization of example B3
+# in interactive session
+#
+# Set some default verbose
+#
+/control/verbose 2
+/control/saveHistory
+/run/verbose 2
+#
+# Change the default number of threads (in multi-threaded mode)
+#/run/numberOfThreads 4
+#
+# Initialize kernel
+/run/initialize
+#
+# create empty scene
+#
+/vis/scene/create
+# open graphics (opengl QT)
+/vis/open OGL

--- a/detectors/EICDetector/vis.mac
+++ b/detectors/EICDetector/vis.mac
@@ -1,0 +1,82 @@
+# $Id: vis.mac,v 1.4 2010/04/14 18:32:59 lindenle Exp $
+#
+# Macro file for the initialization phase of "exampleN03.cc"
+# when running in interactive mode
+#
+# Sets some default verbose
+#
+/control/verbose 2
+/control/saveHistory
+/run/verbose 2
+#
+# create empty scene
+#
+/vis/scene/create
+#
+# Create a scene handler for a specific graphics system
+# (Edit the next line(s) to choose another graphic system)
+#
+# Use this open statement to get an .eps and .prim files
+# suitable for viewing in DAWN.
+###/vis/open DAWNFILE
+#
+# Use this open statement instead for OpenGL in immediate mode.
+# OGLIX works on the desktops in 1008 while OGLSX terminates
+# the X server. I've heard similar stories about OGLIX on other
+# machines. You might have to play with it. GEANT prints out a
+# list of available graphics systems at some point.
+#/vis/open OGLIX
+/vis/open OGL 1200x900-0+0
+# increase display limit for more complex detectors
+/vis/ogl/set/displayListLimit 500000
+/vis/viewer/set/viewpointThetaPhi 240 -40
+/vis/viewer/addCutawayPlane 0 0 0 m 0 -1 0
+# our world is 4x4 meters, the detector is about 1m across
+# zooming by 4 makes it fill the display
+/vis/viewer/zoom 1.5
+#
+# Use this open statement instead to get a HepRep version 1 file
+# suitable for viewing in WIRED.
+#/vis/open HepRepFile
+#
+# Use this open statement instead to get a HepRep version 2 file
+# suitable for viewing in WIRED.
+#/vis/open HepRepXML
+#
+# Output an empty detector
+/vis/viewer/flush
+#
+# Draw trajectories at end of event, showing trajectory points as
+# markers of size 2 pixels
+/vis/scene/add/trajectories smooth
+/vis/modeling/trajectories/create/drawByCharge
+/vis/modeling/trajectories/drawByCharge-0/default/setDrawStepPts true
+/vis/modeling/trajectories/drawByCharge-0/default/setStepPtsSize 2
+# (if too many tracks cause core dump => /tracking/storeTrajectory 0)
+#
+# To draw gammas only
+#/vis/filtering/trajectories/create/particleFilter
+#/vis/filtering/trajectories/particleFilter-0/add gamma
+#
+# To draw charged particles only
+#/vis/filtering/trajectories/particleFilter-0/invert true
+#
+# Many other options available with /vis/modeling and /vis/filtering.
+# For example, select colour by particle ID
+#/vis/modeling/trajectories/create/drawByParticleID
+#/vis/modeling/trajectories/drawByParticleID-0/set e- red
+# remove low energy stuff
+/vis/filtering/trajectories/create/attributeFilter
+/vis/filtering/trajectories/attributeFilter-0/setAttribute IMag
+/vis/filtering/trajectories/attributeFilter-0/addInterval 2 MeV 1000 GeV
+#
+/vis/scene/endOfEventAction accumulate
+#
+# At end of each run, an automatic flush causes graphical output.
+#/run/beamOn 1
+# When you exit Geant4, you will find a file called scene-0.heprep.zip.
+# Unzipping this will give you three separate HepRep files suitable for
+# viewing in WIRED.
+# The first file will contain just detector geometry.
+# The second file will contain the detector plus one event.
+# The third file will contain the detector plus ten events.

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -578,7 +578,9 @@ int Fun4All_G4_FullDetectorModular(
         eval->set_do_FEMC(true);
       if (Enable::EHCAL) 
         eval->set_do_EHCAL(true);
-      if (Enable::FHCAL || Enable::FEMC || Enable::EHCAL) 
+      if (Enable::EEMC) 
+        eval->set_do_EEMC(true);
+      if (Enable::FHCAL || Enable::FEMC || Enable::EHCAL || Enable::EEMC) 
         eval->set_do_CLUSTERS(true);
 //       if (Enable::DRCALO) 
 //         eval->set_do_DRCALO(false);

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -164,13 +164,13 @@ int Fun4All_G4_FullDetectorModular(
     else 
       INPUTGENERATOR::Pythia6->set_config_file(generatorSettings.Data());
     
-    if (specialSetting.Contains("FPartTrigg")){
+    if (generatorSettings.Contains("FPartTrigg")){
       PHPy6ParticleTrigger *ptrig = new PHPy6ParticleTrigger();
       ptrig->SetPtLow(1);
       ptrig->SetEtaHighLow(1,5);
       INPUTGENERATOR::Pythia6->register_trigger(ptrig);
     }
-    if (specialSetting.Contains("FJetTrigg")){
+    if (generatorSettings.Contains("FJetTrigg")){
       PHPy6JetTrigger *trig = new PHPy6JetTrigger();
       trig->SetEtaHighLow(1,5);
       if (generatorSettings.Contains("pTHard5"))

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -324,13 +324,13 @@ int Fun4All_G4_FullDetectorModular(
   Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
   Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && false;
 
-//   EICDetector geometry - barrel
+  // EICDetector geometry - barrel
   Enable::DIRC = true;
-// 
-//   EICDetector geometry - 'hadron' direction
+
+  // EICDetector geometry - 'hadron' direction
   Enable::RICH = true;
   Enable::AEROGEL = true;
-// 
+
   Enable::FEMC = true;
   if(specialSetting.Contains("FHCALSTANDALONE") )
     Enable::FEMC = false;
@@ -350,15 +350,6 @@ int Fun4All_G4_FullDetectorModular(
   Enable::FHCAL_CLUSTER = Enable::FHCAL_TOWER && true;
   Enable::FHCAL_EVAL = Enable::FHCAL_CLUSTER && false;
 
-  Enable::EHCAL = false;
-  if(specialSetting.Contains("FEMCSTANDALONE") )
-    Enable::EHCAL = false;
-  Enable::EHCAL_VERBOSITY = 1;
-  //  Enable::EHCAL_ABSORBER = true;
-  Enable::EHCAL_CELL = Enable::EHCAL && true;
-  Enable::EHCAL_TOWER = Enable::EHCAL_CELL && true;
-  Enable::EHCAL_CLUSTER = Enable::EHCAL_TOWER && true;
-  Enable::EHCAL_EVAL = Enable::EHCAL_CLUSTER && false;
 
   // EICDetector geometry - 'electron' direction
   Enable::EEMC = true;
@@ -369,7 +360,18 @@ int Fun4All_G4_FullDetectorModular(
   Enable::EEMC_CLUSTER = Enable::EEMC_TOWER && true;
   Enable::EEMC_EVAL = Enable::EEMC_CLUSTER && false;
 
-  Enable::PLUGDOOR = true;
+  if (specialSetting.Contains("EHCAL"))
+    Enable::EHCAL = true;
+  if(specialSetting.Contains("FEMCSTANDALONE") )
+    Enable::EHCAL = false;
+  Enable::EHCAL_VERBOSITY = 1;
+  //  Enable::EHCAL_ABSORBER = true;
+  Enable::EHCAL_CELL = Enable::EHCAL && true;
+  Enable::EHCAL_TOWER = Enable::EHCAL_CELL && true;
+  Enable::EHCAL_CLUSTER = Enable::EHCAL_TOWER && true;
+  Enable::EHCAL_EVAL = Enable::EHCAL_CLUSTER && false;
+
+  Enable::PLUGDOOR = false;
 
   // deactivate all detector systems for FHCal standalone studies
   if(specialSetting.Contains("FHCALSTANDALONE")){
@@ -379,7 +381,7 @@ int Fun4All_G4_FullDetectorModular(
     G4TRACKING::PROJECTION_CEMC = false;
     G4TRACKING::PROJECTION_FEMC = false;
     G4TRACKING::PROJECTION_FHCAL = false;
-    // G4TRACKING::PROJECTION_EHCAL = false;
+    G4TRACKING::PROJECTION_EHCAL = false;
     Enable::MAGNET = false;
     Enable::DIRC = false;
     Enable::RICH = false;
@@ -394,7 +396,7 @@ int Fun4All_G4_FullDetectorModular(
     G4TRACKING::PROJECTION_CEMC = false;
     G4TRACKING::PROJECTION_FEMC = false;
     G4TRACKING::PROJECTION_FHCAL = false;
-    // G4TRACKING::PROJECTION_EHCAL = false;
+    G4TRACKING::PROJECTION_EHCAL = false;
     Enable::MAGNET = false;
     Enable::DIRC = false;
     Enable::RICH = false;
@@ -409,6 +411,7 @@ int Fun4All_G4_FullDetectorModular(
     G4TRACKING::PROJECTION_CEMC = false;
     G4TRACKING::PROJECTION_FEMC = false;
     G4TRACKING::PROJECTION_FHCAL = false;
+    G4TRACKING::PROJECTION_EHCAL = false;
     Enable::MAGNET = false;
     Enable::DIRC = false;
     Enable::RICH = false;
@@ -507,14 +510,14 @@ int Fun4All_G4_FullDetectorModular(
   if (Enable::FEMC_TOWER) FEMC_Towers();
   if (Enable::FEMC_CLUSTER) FEMC_Clusters();
 
-  if (Enable::EHCAL_TOWER) EHCAL_Towers();
-  if (Enable::EHCAL_CLUSTER) EHCAL_Clusters();
-
   if (Enable::FHCAL_TOWER) FHCAL_Towers();
   if (Enable::FHCAL_CLUSTER) FHCAL_Clusters();
 
   if (Enable::EEMC_TOWER) EEMC_Towers();
   if (Enable::EEMC_CLUSTER) EEMC_Clusters();
+
+  if (Enable::EHCAL_TOWER) EHCAL_Towers();
+  if (Enable::EHCAL_CLUSTER) EHCAL_Clusters();
 
   if (Enable::DSTOUT_COMPRESS) ShowerCompress();
 
@@ -569,32 +572,29 @@ int Fun4All_G4_FullDetectorModular(
       eval->set_do_FEMC(true);
       eval->set_do_CLUSTERS(true);
     } else {
-      eval->set_do_FHCAL(true);
-      // eval->set_do_EHCAL(true);
-      eval->set_do_FEMC(true);
-      eval->set_do_CLUSTERS(true);
-      eval->set_do_HITS(true);
-      eval->set_do_TRACKS(true);
-      eval->set_do_VERTEX(true);
-      eval->set_do_PROJECTIONS(true);
+      if (Enable::FHCAL) 
+        eval->set_do_FHCAL(true);
+      if (Enable::FEMC) 
+        eval->set_do_FEMC(true);
+      if (Enable::EHCAL) 
+        eval->set_do_EHCAL(true);
+      if (Enable::FHCAL || Enable::FEMC || Enable::EHCAL) 
+        eval->set_do_CLUSTERS(true);
+//       if (Enable::DRCALO) 
+//         eval->set_do_DRCALO(false);
+      
+      if (Enable::TRACKING){
+        eval->set_do_TRACKS(true);
+        eval->set_do_HITS(true);  
+        eval->set_do_PROJECTIONS(true);
+        if (G4TRACKING::DISPLACED_VERTEX) eval->set_do_VERTEX(true);
+      }
     }
     eval->set_do_MCPARTICLES(true);
     se->registerSubsystem(eval);
   }
 
   if (specialSetting.Contains("TRACKEVALHITS")) Tracking_Eval(outputroot + "_g4tracking_eval.root", specialSetting);
-  // if (Enable::CEMC_EVAL) CEMC_Eval(outputroot + "_g4cemc_eval.root");
-  // if (Enable::HCALIN_EVAL) HCALInner_Eval(outputroot + "_g4hcalin_eval.root");
-  // if (Enable::HCALOUT_EVAL) HCALOuter_Eval(outputroot + "_g4hcalout_eval.root");
-  // if (Enable::FEMC_EVAL) FEMC_Eval(outputroot + "_g4femc_eval.root");
-  // if (Enable::FHCAL_EVAL) FHCAL_Eval(outputroot + "_g4fhcal_eval.root");
-  // if (Enable::EEMC_EVAL) EEMC_Eval(outputroot + "_g4eemc_eval.root");
-  // if (Enable::JETS_EVAL) Jet_Eval(outputroot + "_g4jet_eval.root");
-  // if (Enable::FWDJETS_EVAL) Jet_FwdEval(outputroot + "_g4fwdjet_eval.root");
-  // if (Enable::USER) UserAnalysisInit();
-
-  // if (Enable::JETS_QA) Jet_QA();
-
   //--------------
   // Set up Input Managers
   //--------------

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -283,7 +283,7 @@ int Fun4All_G4_FullDetectorModular(
   Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
   Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && false;
 
-  Enable::HCALIN = true;
+//   Enable::HCALIN = true;
   if(specialSetting.Contains("FHCALSTANDALONE") || specialSetting.Contains("FEMCSTANDALONE") || specialSetting.Contains("CALOSTANDALONE"))
     Enable::HCALIN = false;
   //  Enable::HCALIN_ABSORBER = true;
@@ -292,9 +292,9 @@ int Fun4All_G4_FullDetectorModular(
   Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
   Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && false;
 
-  Enable::MAGNET = true;
+//   Enable::MAGNET = true;
 
-  Enable::HCALOUT = true;
+//   Enable::HCALOUT = true;
   if(specialSetting.Contains("FHCALSTANDALONE") || specialSetting.Contains("FEMCSTANDALONE") || specialSetting.Contains("CALOSTANDALONE"))
     Enable::HCALOUT = false;
   //  Enable::HCALOUT_ABSORBER = true;
@@ -304,11 +304,11 @@ int Fun4All_G4_FullDetectorModular(
   Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && false;
 
   // EICDetector geometry - barrel
-  Enable::DIRC = true;
+//   Enable::DIRC = true;
 
   // EICDetector geometry - 'hadron' direction
-  Enable::RICH = true;
-  Enable::AEROGEL = true;
+//   Enable::RICH = true;
+//   Enable::AEROGEL = true;
 
   Enable::FEMC = true;
   if(specialSetting.Contains("FHCALSTANDALONE") )
@@ -319,7 +319,7 @@ int Fun4All_G4_FullDetectorModular(
   Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
   Enable::FEMC_EVAL = Enable::FEMC_CLUSTER && false;
 
-  Enable::FHCAL = true;
+//   Enable::FHCAL = true;
   if(specialSetting.Contains("FEMCSTANDALONE") )
     Enable::FHCAL = false;
   Enable::FHCAL_VERBOSITY = 1;

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -137,29 +137,29 @@ int Fun4All_G4_FullDetectorModular(
   }
   // pythia6
   if (Input::PYTHIA6){
-    if (generatorSettings.CompareTo("e10p250MB") == 0)
+    if (generatorSettings.Contains("e10p250MB") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep.cfg");
-    else if (generatorSettings.CompareTo("e10p250pTHard5") == 0)
+    else if (generatorSettings.Contains("e10p250pTHard5") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP5GeV.cfg");
-    else if (generatorSettings.CompareTo("e10p250pTHard10") == 0)
+    else if (generatorSettings.Contains("e10p250pTHard10"))
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP10GeV.cfg");
-    else if (generatorSettings.CompareTo("e10p250pTHard20") == 0)
+    else if (generatorSettings.Contains("e10p250pTHard20"))
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP20GeV.cfg");
-    else if (generatorSettings.CompareTo("e5p100MB") == 0)
+    else if (generatorSettings.Contains("e5p100MB") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e5p100.cfg");
-    else if (generatorSettings.CompareTo("e5p100pTHard5") == 0)
+    else if (generatorSettings.Contains("e5p100pTHard5") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e5p100_MinPartonP5GeV.cfg");
-    else if (generatorSettings.CompareTo("e10p275MB") == 0)
+    else if (generatorSettings.Contains("e10p275MB") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275.cfg");
-    else if (generatorSettings.CompareTo("e10p275pTHard5") == 0)
+    else if (generatorSettings.Contains("e10p275pTHard5") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275_MinPartonP5GeV.cfg");
-    else if (generatorSettings.CompareTo("e10p275pTHard10") == 0)
+    else if (generatorSettings.Contains("e10p275pTHard10") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275_MinPartonP10GeV.cfg");
-    else if (generatorSettings.CompareTo("e18p275MB") == 0)
+    else if (generatorSettings.Contains("e18p275MB") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275.cfg");
-    else if (generatorSettings.CompareTo("e18p275pTHard5") == 0)
+    else if (generatorSettings.Contains("e18p275pTHard5") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275_MinPartonP5GeV.cfg");
-    else if (generatorSettings.CompareTo("e18p275pTHard10") == 0)
+    else if (generatorSettings.Contains("e18p275pTHard10") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275_MinPartonP10GeV.cfg");
     else 
       INPUTGENERATOR::Pythia6->set_config_file(generatorSettings.Data());
@@ -184,6 +184,10 @@ int Fun4All_G4_FullDetectorModular(
       trig->SetJetR(0.7);
       INPUTGENERATOR::Pythia6->register_trigger(trig);
     }
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::Pythia6);
+
+    
   }
 
   // register all input generators with Fun4All
@@ -226,13 +230,22 @@ int Fun4All_G4_FullDetectorModular(
   // EIC beam pipe extension beyond the Be-section:
   G4PIPE::use_forward_pipes = true;
 
-  if (specialSetting.Contains("EGEM"))
+  // backward GEM
+  if (specialSetting.Contains("EGEM")){
     Enable::EGEM = true;
-  if (specialSetting.Contains("EGEMOO")) // only last 2 EGEM layers
-    Enable::EGEM_FULL = false;
+    if (specialSetting.Contains("EGEMOO")) // only last 2 EGEM layers
+      Enable::EGEM_FULL = false;
+  }
   //Forward GEM
-  if (specialSetting.Contains("FGEM"))
+  if (specialSetting.Contains("FGEM")){
     Enable::FGEM = true;
+     // FGEM settings
+    if (specialSetting.Contains("FGEMOrg")){
+      Enable::FGEM_ORIG = true;
+    } else {
+      Enable::FGEM_ORIG = false;
+    }
+  }
   
   // barrel tracker (LANL)
   if (specialSetting.Contains("BARREL"))
@@ -270,10 +283,18 @@ int Fun4All_G4_FullDetectorModular(
   
   G4TRACKING::DISPLACED_VERTEX = true;  // this option exclude vertex in the track fitting and use RAVE to reconstruct primary and 2ndary vertexes
                                          // projections to calorimeters
-  G4TRACKING::PROJECTION_CEMC = true;
-  G4TRACKING::PROJECTION_FEMC = true;
-  G4TRACKING::PROJECTION_FHCAL = true;
-
+                                         
+  if (specialSetting.Contains("TRACKEVALHITS")){
+    G4TRACKING::PROJECTION_CEMC = false;
+    G4TRACKING::PROJECTION_FEMC = false;
+    G4TRACKING::PROJECTION_FHCAL = false;
+    G4TRACKING::PROJECTION_EEMC = false;
+  } else {
+    G4TRACKING::PROJECTION_CEMC = true;
+    G4TRACKING::PROJECTION_FEMC = true;
+    G4TRACKING::PROJECTION_FHCAL = true;
+    G4TRACKING::PROJECTION_EEMC = true;    
+  }
   Enable::CEMC = true;
   if(specialSetting.Contains("FHCALSTANDALONE") || specialSetting.Contains("FEMCSTANDALONE") || specialSetting.Contains("CALOSTANDALONE"))
     Enable::CEMC = false;
@@ -283,7 +304,7 @@ int Fun4All_G4_FullDetectorModular(
   Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
   Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && false;
 
-//   Enable::HCALIN = true;
+  Enable::HCALIN = true;
   if(specialSetting.Contains("FHCALSTANDALONE") || specialSetting.Contains("FEMCSTANDALONE") || specialSetting.Contains("CALOSTANDALONE"))
     Enable::HCALIN = false;
   //  Enable::HCALIN_ABSORBER = true;
@@ -292,9 +313,9 @@ int Fun4All_G4_FullDetectorModular(
   Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
   Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && false;
 
-//   Enable::MAGNET = true;
+  Enable::MAGNET = true;
 
-//   Enable::HCALOUT = true;
+  Enable::HCALOUT = true;
   if(specialSetting.Contains("FHCALSTANDALONE") || specialSetting.Contains("FEMCSTANDALONE") || specialSetting.Contains("CALOSTANDALONE"))
     Enable::HCALOUT = false;
   //  Enable::HCALOUT_ABSORBER = true;
@@ -303,13 +324,13 @@ int Fun4All_G4_FullDetectorModular(
   Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
   Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && false;
 
-  // EICDetector geometry - barrel
-//   Enable::DIRC = true;
-
-  // EICDetector geometry - 'hadron' direction
-//   Enable::RICH = true;
-//   Enable::AEROGEL = true;
-
+//   EICDetector geometry - barrel
+  Enable::DIRC = true;
+// 
+//   EICDetector geometry - 'hadron' direction
+  Enable::RICH = true;
+  Enable::AEROGEL = true;
+// 
   Enable::FEMC = true;
   if(specialSetting.Contains("FHCALSTANDALONE") )
     Enable::FEMC = false;
@@ -319,7 +340,7 @@ int Fun4All_G4_FullDetectorModular(
   Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
   Enable::FEMC_EVAL = Enable::FEMC_CLUSTER && false;
 
-//   Enable::FHCAL = true;
+  Enable::FHCAL = true;
   if(specialSetting.Contains("FEMCSTANDALONE") )
     Enable::FHCAL = false;
   Enable::FHCAL_VERBOSITY = 1;
@@ -552,7 +573,6 @@ int Fun4All_G4_FullDetectorModular(
       // eval->set_do_EHCAL(true);
       eval->set_do_FEMC(true);
       eval->set_do_CLUSTERS(true);
-      eval->set_do_DRCALO(false);
       eval->set_do_HITS(true);
       eval->set_do_TRACKS(true);
       eval->set_do_VERTEX(true);
@@ -562,7 +582,7 @@ int Fun4All_G4_FullDetectorModular(
     se->registerSubsystem(eval);
   }
 
-  // if (Enable::TRACKING_EVAL) Tracking_Eval(outputroot + "_g4tracking_eval.root", specialSetting);
+  if (specialSetting.Contains("TRACKEVALHITS")) Tracking_Eval(outputroot + "_g4tracking_eval.root", specialSetting);
   // if (Enable::CEMC_EVAL) CEMC_Eval(outputroot + "_g4cemc_eval.root");
   // if (Enable::HCALIN_EVAL) HCALInner_Eval(outputroot + "_g4hcalin_eval.root");
   // if (Enable::HCALOUT_EVAL) HCALOuter_Eval(outputroot + "_g4hcalout_eval.root");
@@ -691,6 +711,10 @@ void ParseTString(TString &specialSetting)
   {
     G4FST::SETTING::FSTV42 = true;
   }
+  else if (specialSetting.Contains("FSTVTPC"))
+  {
+    G4FST::SETTING::FST_TPC = true;
+  }
   else if (specialSetting.Contains("FST"))
   {
     G4FST::SETTING::FSTV0 = true;
@@ -736,6 +760,7 @@ void ParseTString(TString &specialSetting)
   {
     G4FHCAL::SETTING::towercalib3 = true;
   }
+  
 }
 
 #endif

--- a/detectors/Modular/G4Setup_ModularDetector.C
+++ b/detectors/Modular/G4Setup_ModularDetector.C
@@ -53,7 +53,7 @@ void G4Init()
 {
   // First some check for subsystems which do not go together
 
-  if (Enable::TPC && Enable::FST){
+  if (Enable::TPC && Enable::FST && !G4FST::SETTING::FST_TPC){
     cout << "TPC and FST cannot be enabled together" << endl;
     gSystem->Exit(1);
   } else if ((Enable::TPC || Enable::MVTX) && Enable::BARREL){

--- a/detectors/ModularBeast/Fun4All_G4_FullDetectorModularBeast.C
+++ b/detectors/ModularBeast/Fun4All_G4_FullDetectorModularBeast.C
@@ -140,33 +140,33 @@ int Fun4All_G4_FullDetectorModularBeast(
   }
   // pythia6
   if (Input::PYTHIA6){
-    if (generatorSettings.CompareTo("e10p250MB") == 0)
+  if (generatorSettings.Contains("e10p250MB") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep.cfg");
-    else if (generatorSettings.CompareTo("e10p250pTHard5") == 0)
+    else if (generatorSettings.Contains("e10p250pTHard5") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP5GeV.cfg");
-    else if (generatorSettings.CompareTo("e10p250pTHard10") == 0)
+    else if (generatorSettings.Contains("e10p250pTHard10"))
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP10GeV.cfg");
-    else if (generatorSettings.CompareTo("e10p250pTHard20") == 0)
+    else if (generatorSettings.Contains("e10p250pTHard20"))
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP20GeV.cfg");
-    else if (generatorSettings.CompareTo("e5p100MB") == 0)
+    else if (generatorSettings.Contains("e5p100MB") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e5p100.cfg");
-    else if (generatorSettings.CompareTo("e5p100pTHard5") == 0)
+    else if (generatorSettings.Contains("e5p100pTHard5") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e5p100_MinPartonP5GeV.cfg");
-    else if (generatorSettings.CompareTo("e10p275MB") == 0)
+    else if (generatorSettings.Contains("e10p275MB") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275.cfg");
-    else if (generatorSettings.CompareTo("e10p275pTHard5") == 0)
+    else if (generatorSettings.Contains("e10p275pTHard5") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275_MinPartonP5GeV.cfg");
-    else if (generatorSettings.CompareTo("e10p275pTHard10") == 0)
+    else if (generatorSettings.Contains("e10p275pTHard10") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e10p275_MinPartonP10GeV.cfg");
-    else if (generatorSettings.CompareTo("e18p275MB") == 0)
+    else if (generatorSettings.Contains("e18p275MB") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275.cfg");
-    else if (generatorSettings.CompareTo("e18p275pTHard5") == 0)
+    else if (generatorSettings.Contains("e18p275pTHard5") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275_MinPartonP5GeV.cfg");
-    else if (generatorSettings.CompareTo("e18p275pTHard10") == 0)
+    else if (generatorSettings.Contains("e18p275pTHard10") )
       INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_e18p275_MinPartonP10GeV.cfg");
     else 
       INPUTGENERATOR::Pythia6->set_config_file(generatorSettings.Data());
-    
+      
     if (generatorSettings.Contains("FPartTrigg")){
       PHPy6ParticleTrigger *ptrig = new PHPy6ParticleTrigger();
       ptrig->SetPtLow(1);
@@ -187,6 +187,9 @@ int Fun4All_G4_FullDetectorModularBeast(
       trig->SetJetR(0.7);
       INPUTGENERATOR::Pythia6->register_trigger(trig);
     }
+    //! apply EIC beam parameter following EIC CDR
+//     Input::ApplyEICBeamParameter(INPUTGENERATOR::Pythia6);
+
   }
 
   // register all input generators with Fun4All
@@ -225,14 +228,22 @@ int Fun4All_G4_FullDetectorModularBeast(
   // EIC beam pipe extension beyond the Be-section:
   G4PIPE::use_forward_pipes = true;
 
-  
-    if (specialSetting.Contains("EGEM"))
+  // backward GEM
+  if (specialSetting.Contains("EGEM")){
     Enable::EGEM = true;
-  if (specialSetting.Contains("EGEMOO")) // only last 2 EGEM layers
-    Enable::EGEM_FULL = false;
+    if (specialSetting.Contains("EGEMOO")) // only last 2 EGEM layers
+      Enable::EGEM_FULL = false;
+  }
   //Forward GEM
-  if (specialSetting.Contains("FGEM"))
+  if (specialSetting.Contains("FGEM")){
     Enable::FGEM = true;
+     // FGEM settings
+    if (specialSetting.Contains("FGEMOrg")){
+      Enable::FGEM_ORIG = true;
+    } else {
+      Enable::FGEM_ORIG = false;
+    }
+  }
   
   // barrel tracker (LANL)
   if (specialSetting.Contains("BARREL"))
@@ -270,9 +281,17 @@ int Fun4All_G4_FullDetectorModularBeast(
   
   G4TRACKING::DISPLACED_VERTEX = true;  // this option exclude vertex in the track fitting and use RAVE to reconstruct primary and 2ndary vertexes
                                          // projections to calorimeters
-  G4TRACKING::PROJECTION_CEMC = true;
-  G4TRACKING::PROJECTION_FEMC = true;
-  G4TRACKING::PROJECTION_FHCAL = true;
+  if (specialSetting.Contains("TRACKEVALHITS")){
+    G4TRACKING::PROJECTION_CEMC = false;
+    G4TRACKING::PROJECTION_FEMC = false;
+    G4TRACKING::PROJECTION_FHCAL = false;
+    G4TRACKING::PROJECTION_EEMC = false;
+  } else {
+    G4TRACKING::PROJECTION_CEMC = true;
+    G4TRACKING::PROJECTION_FEMC = true;
+    G4TRACKING::PROJECTION_FHCAL = true;
+    G4TRACKING::PROJECTION_EEMC = true;    
+  }
 
   Enable::CEMC = true;
   if(specialSetting.Contains("FHCALSTANDALONE") || specialSetting.Contains("FEMCSTANDALONE") || specialSetting.Contains("CALOSTANDALONE"))
@@ -516,7 +535,7 @@ int Fun4All_G4_FullDetectorModularBeast(
     se->registerSubsystem(eval);
   }
 
-//   if (Enable::TRACKING_EVAL) Tracking_Eval(outputroot + "_g4tracking_eval.root", specialSetting);
+  if (specialSetting.Contains("TRACKEVALHITS")) Tracking_Eval(outputroot + "_g4tracking_eval.root", specialSetting);
   // if (Enable::CEMC_EVAL) CEMC_Eval(outputroot + "_g4cemc_eval.root");
   // if (Enable::HCALIN_EVAL) HCALInner_Eval(outputroot + "_g4hcalin_eval.root");
   // if (Enable::HCALOUT_EVAL) HCALOuter_Eval(outputroot + "_g4hcalout_eval.root");
@@ -644,6 +663,10 @@ void ParseTString(TString &specialSetting)
   else if (specialSetting.Contains("FSTV42"))
   {
     G4FST::SETTING::FSTV42 = true;
+  }
+  else if (specialSetting.Contains("FSTVTPC"))
+  {
+    G4FST::SETTING::FST_TPC = true;
   }
   else if (specialSetting.Contains("FST"))
   {

--- a/detectors/ModularBeast/Fun4All_G4_FullDetectorModularBeast.C
+++ b/detectors/ModularBeast/Fun4All_G4_FullDetectorModularBeast.C
@@ -167,13 +167,13 @@ int Fun4All_G4_FullDetectorModularBeast(
     else 
       INPUTGENERATOR::Pythia6->set_config_file(generatorSettings.Data());
     
-    if (specialSetting.Contains("FPartTrigg")){
+    if (generatorSettings.Contains("FPartTrigg")){
       PHPy6ParticleTrigger *ptrig = new PHPy6ParticleTrigger();
       ptrig->SetPtLow(1);
       ptrig->SetEtaHighLow(1,5);
       INPUTGENERATOR::Pythia6->register_trigger(ptrig);
     }
-    if (specialSetting.Contains("FJetTrigg")){
+    if (generatorSettings.Contains("FJetTrigg")){
       PHPy6JetTrigger *trig = new PHPy6JetTrigger();
       trig->SetEtaHighLow(1,5);
       if (generatorSettings.Contains("pTHard5"))

--- a/detectors/fsPHENIX/DisplayOn.C
+++ b/detectors/fsPHENIX/DisplayOn.C
@@ -1,0 +1,64 @@
+#ifndef MACRO_DISPLAYON_C
+#define MACRO_DISPLAYON_C
+
+#include <g4main/PHG4Reco.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libg4testbench.so)
+
+namespace Enable
+{
+  bool DISPLAY = false;
+}
+
+// This starts the QT based G4 gui which takes control
+// when x'ed out it will return a pointer to PHG4Reco so
+// the gui can be startrd again
+PHG4Reco *QTGui()
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
+  g4->StartGui();
+  return g4;
+}
+
+// stupid macro to turn on the geant4 display
+// we ask Fun4All for a pointer to PHG4Reco
+// using the ApplyCommand will start up the
+// G4 cmd interpreter and graphics system
+// the vis.mac contains the necessary commands to
+// start up the visualization, the next event will
+// be displayed. Do not execute this macro
+// before PHG4Reco was registered with Fun4All
+PHG4Reco * DisplayOn(const char *mac = "vis.mac")
+{
+  char cmd[100];
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
+  sprintf(cmd, "/control/execute %s", mac);
+  g4->ApplyCommand(cmd);
+  return g4;
+}
+// print out the commands I always forget
+void displaycmd()
+{
+  cout << "draw axis: " << endl;
+  cout << " g4->ApplyCommand(\"/vis/scene/add/axes 0 0 0 50 cm\")" << endl;
+  cout << "zoom" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/zoom 1\")" << endl;
+  cout << "viewpoint:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/set/viewpointThetaPhi 0 0\")" << endl;
+  cout << "panTo:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/panTo 0 0 cm\")" << endl;
+  cout << "print to eps:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/ogl/printEPS\")" << endl;
+  cout << "set background color:" << endl;
+  cout << " g4->ApplyCommand(\"/vis/viewer/set/background white\")" << endl;
+}
+#endif

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -1,0 +1,572 @@
+#ifndef MACRO_FUN4ALLG4FSPHENIX_C
+#define MACRO_FUN4ALLG4FSPHENIX_C
+
+#include <GlobalVariables.C>
+
+#include <DisplayOn.C>
+#include <G4Setup_fsPHENIX.C>
+#include <G4_Bbc.C>
+#include <G4_CaloTrigger.C>
+#include <G4_DSTReader_fsPHENIX.C>
+#include <G4_FwdJets.C>
+#include <G4_Global.C>
+#include <G4_Input.C>
+#include <G4_Tracking.C>
+#include <G4_Jets.C>
+#include <G4_Production.C>
+#include <G4_User.C>
+
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <phool/recoConsts.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+
+// If using the default embedding file results in a error, try
+// TFile *f1 = TFile::Open("http://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/fsPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root")
+// if it returns a certificate error, something like
+// Error in <DavixOpen>: can not open file with davix: Failure (Neon): Server certificate verification failed: bad certificate chain after 3 attempts (6)
+// add the line
+// Davix.GSI.CACheck: n
+// to your .rootrc
+
+int Fun4All_G4_fsPHENIX(
+    const int nEvents = 2,
+    const string &inputFile = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/fsPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
+    const string &outputFile = "G4fsPHENIX.root",
+    const string &embed_input_file = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/fsPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
+    const int skip = 0,
+    const string &outdir = ".")
+{
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->Verbosity(0);
+  // Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
+  // PHRandomSeed::Verbosity(1);
+  // just if we set some flags somewhere in this macro
+  recoConsts *rc = recoConsts::instance();
+  // By default every random number generator uses
+  // PHRandomSeed() which reads /dev/urandom to get its seed
+  // if the RANDOMSEED flag is set its value is taken as initial seed
+  // which will produce identical results so you can debug your code
+  //  rc->set_IntFlag("RANDOMSEED", 12345);
+
+  //===============
+  // Input options
+  //===============
+  // verbosity setting (applies to all input managers)
+  Input::VERBOSITY = 0;
+  // Either:
+  // read previously generated g4-hits files, in this case it opens a DST and skips
+  // the simulations step completely. The G4Setup macro is only loaded to get information
+  // about the number of layers used for the cell reco code
+  Input::READHITS = false;
+  INPUTREADHITS::filename[0] = inputFile;
+  // if you use a filelist
+  // INPUTREADHITS::listfile[0] = inputFile;
+  // Or:
+  // Use particle generator
+  // And
+  // Further choose to embed newly simulated events to a previous simulation. Not compatible with `readhits = true`
+  // In case embedding into a production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
+  // E.g. /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/
+
+  //  Input::EMBED = true;
+  INPUTEMBED::filename[0] = embed_input_file;
+  // if you use a filelist
+  //INPUTEMBED::listfile[0] = embed_input_file;
+
+  Input::SIMPLE = true;
+  // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
+  // Input::SIMPLE_VERBOSITY = 1;
+
+  //  Input::PYTHIA6 = true;
+
+  //  Input::PYTHIA8 = true;
+
+  //  Input::GUN = true;
+  //  Input::GUN_NUMBER = 3; // if you need 3 of them
+  // Input::GUN_VERBOSITY = 1;
+
+  // Upsilon generator
+  //  Input::UPSILON = true;
+  // Input::UPSILON_NUMBER = 3; // if you need 3 of them
+  // Input::UPSILON_VERBOSITY = 0;
+
+  //  Input::HEPMC = true;
+  INPUTHEPMC::filename = inputFile;
+
+  // Event pile up simulation with collision rate in Hz MB collisions.
+  Input::PILEUPRATE = 100e3;
+
+  //-----------------
+  // Initialize the selected Input/Event generation
+  //-----------------
+  InputInit();
+
+  //--------------
+  // Set generator specific options
+  //--------------
+  // can only be set after InputInit() is called
+
+  // Simple Input generator:
+  // if you run more than one of these Input::SIMPLE_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
+  if (Input::SIMPLE)
+  {
+    INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi-", 5);
+    if (Input::HEPMC || Input::EMBED)
+    {
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+    }
+    else
+    {
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
+                                                                                PHG4SimpleEventGenerator::Uniform,
+                                                                                PHG4SimpleEventGenerator::Uniform);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
+    }
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-1, 3);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(0.5, 50.);
+  }
+  // Upsilons
+  // if you run more than one of these Input::UPSILON_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
+  if (Input::UPSILON)
+  {
+    INPUTGENERATOR::VectorMesonGenerator[0]->add_decay_particles("mu", 0);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_rapidity_range(-1, 1);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
+    // Y species - select only one, last one wins
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
+    if (Input::HEPMC || Input::EMBED)
+    {
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+    }
+  }
+  // particle gun
+  // if you run more than one of these Input::GUN_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
+  if (Input::GUN)
+  {
+    INPUTGENERATOR::Gun[0]->AddParticle("pi-", 0, 1, 0);
+    INPUTGENERATOR::Gun[0]->set_vtx(0, 0, 0);
+  }
+
+  // pythia6
+  if (Input::PYTHIA6)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia6);
+  }
+  // pythia8
+  if (Input::PYTHIA8)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia8);
+  }
+
+  //--------------
+  // Set Input Manager specific options
+  //--------------
+  // can only be set after InputInit() is called
+
+  if (Input::HEPMC)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCInputManager);
+
+    // optional overriding beam parameters
+    //INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 8, 0);  //optional collision smear in space, time
+    //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
+    // //optional choice of vertex distribution function in space, time
+    //INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
+    if (Input::PILEUPRATE > 0)
+    {
+      // Copy vertex settings from foreground hepmc input
+      INPUTMANAGER::HepMCPileupInputManager->CopyHelperSettings(INPUTMANAGER::HepMCInputManager);
+      // and then modify the ones you want to be different
+      // INPUTMANAGER::HepMCPileupInputManager->set_vertex_distribution_width(100e-4,100e-4,8,0);
+    }
+  }
+  if (Input::PILEUPRATE > 0)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCPileupInputManager);
+  }
+
+  // register all input generators with Fun4All
+  InputRegister();
+
+  // set up production relatedstuff
+  //   Enable::PRODUCTION = true;
+
+  //======================
+  // Write the DST
+  //======================
+
+  //Enable::DSTOUT = true;
+  Enable::DSTOUT_COMPRESS = false;
+  DstOut::OutputDir = outdir;
+  DstOut::OutputFile = outputFile;
+
+  //Option to convert DST to human command readable TTree for quick poke around the outputs
+  //  Enable::DSTREADER = true;
+
+  // turn the display on (default off)
+  Enable::DISPLAY = false;
+
+  //======================
+  // What to run
+  //======================
+  // Global options (enabled for all enables subsystems - if implemented)
+  //  Enable::ABSORBER = true;
+  //  Enable::OVERLAPCHECK = true;
+  //  Enable::VERBOSITY = 1;
+
+  //  Enable::BBC = true;
+  Enable::BBCFAKE = true; // Smeared vtx and t0, use if you don't want real BBC in simulation
+
+  Enable::PIPE = true;
+  Enable::PIPE_ABSORBER = true;
+  //  Enable::PIPE_OVERLAPCHECK = true;
+
+  // central tracking
+  Enable::MVTX = true;
+  Enable::MVTX_CELL = Enable::MVTX && true;
+  Enable::MVTX_CLUSTER = Enable::MVTX_CELL && true;
+
+  Enable::INTT = true;
+  Enable::INTT_CELL = Enable::INTT && true;
+  Enable::INTT_CLUSTER = Enable::INTT_CELL && true;
+
+  Enable::TPC = true;
+  //  Enable::TPC_ABSORBER = true;
+  Enable::TPC_CELL = Enable::TPC && true;
+  Enable::TPC_CLUSTER = Enable::TPC_CELL && true;
+
+  Enable::TRACKING_TRACK = Enable::TPC_CELL && Enable::INTT_CELL && Enable::MVTX_CELL && true;
+  Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
+
+  // central calorimeters, which is a detailed simulation and slow to run
+  Enable::CEMC = true;
+  //  Enable::CEMC_ABSORBER = true;
+  Enable::CEMC_CELL = Enable::CEMC && true;
+  Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
+  Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
+  Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
+
+  Enable::HCALIN = true;
+  //  Enable::HCALIN_ABSORBER = true;
+  Enable::HCALIN_CELL = Enable::HCALIN && true;
+  Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
+  Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
+  Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && true;
+
+  Enable::MAGNET = true;
+  //  Enable::MAGNET_ABSORBER = true;
+
+  Enable::HCALOUT = true;
+  //  Enable::HCALOUT_ABSORBER = true;
+  Enable::HCALOUT_CELL = Enable::HCALOUT && true;
+  Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
+  Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
+  Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && true;
+
+  Enable::GLOBAL_RECO = true;
+  //  Enable::GLOBAL_FASTSIM = true;
+
+  Enable::CALOTRIGGER = Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER && true;
+
+  Enable::JETS = true;
+  Enable::JETS_EVAL = Enable::JETS && true;
+
+  Enable::FWDJETS = true;
+  Enable::FWDJETS_EVAL = Enable::FWDJETS && true;
+
+  // fsPHENIX geometry
+
+  Enable::FGEM = true;
+  Enable::FGEM_TRACK = Enable::FGEM && Enable::MVTX && true;
+  Enable::FGEM_EVAL = Enable::FGEM_TRACK && true;
+
+  Enable::FEMC = true;
+  Enable::FEMC_ABSORBER = true;
+  Enable::FEMC_TOWER = Enable::FEMC && true;
+  Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
+
+  Enable::FHCAL = true;
+  Enable::FHCAL_ABSORBER = true;
+  Enable::FHCAL_TOWER = Enable::FHCAL && true;
+  Enable::FHCAL_CLUSTER = Enable::FHCAL_TOWER && true;
+  Enable::FHCAL_EVAL = Enable::FHCAL_CLUSTER && true;
+
+  //  Enable::PISTON = true;
+  Enable::PISTON_ABSORBER = true;
+  Enable::PISTON_OVERLAPCHECK = false;
+
+  Enable::PLUGDOOR = true;
+  //  Enable::PLUGDOOR_ABSORBER = true;
+  Enable::PLUGDOOR_OVERLAPCHECK = false;
+
+  // new settings using Enable namespace in GlobalVariables.C
+  Enable::BLACKHOLE = true;
+  //Enable::BLACKHOLE_SAVEHITS = false; // turn off saving of bh hits
+  //  BlackHoleGeometry::visible = true;
+
+  // run user provided code (from local G4_User.C)
+  //Enable::USER = true;
+
+  //---------------
+  // World Settings
+  //---------------
+  //  G4WORLD::PhysicsList = "FTFP_BERT"; // FTFP_BERT_HP best for calo
+  //  G4WORLD::WorldMaterial = "G4_AIR"; // set to G4_GALACTIC for material scans
+
+  //---------------
+  // Magnet Settings
+  //---------------
+
+  //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+  //  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // default map from the calibration database
+  G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
+
+  //---------------
+  // Pythia Decayer
+  //---------------
+  // list of decay types in
+  // $OFFLINE_MAIN/include/g4decayer/EDecayType.hh
+  // default is All:
+  // G4P6DECAYER::decayType = EDecayType::kAll;
+
+  // Initialize the selected subsystems
+  G4Init();
+
+  if (!Input::READHITS)
+  {
+    //---------------------
+    // Set up G4 only if we do not read hits
+    //---------------------
+    G4Setup();
+  }
+
+  //------------------
+  // Detector Division
+  //------------------
+
+  if (Enable::BBC || Enable::BBCFAKE) Bbc_Reco();
+
+  if (Enable::MVTX_CELL) Mvtx_Cells();
+  if (Enable::INTT_CELL) Intt_Cells();
+  if (Enable::TPC_CELL) TPC_Cells();
+
+  if (Enable::CEMC_CELL) CEMC_Cells();
+
+  if (Enable::HCALIN_CELL) HCALInner_Cells();
+
+  if (Enable::HCALOUT_CELL) HCALOuter_Cells();
+
+  //-----------------------------
+  // CEMC towering and clustering
+  //-----------------------------
+
+  if (Enable::CEMC_TOWER) CEMC_Towers();
+  if (Enable::CEMC_CLUSTER) CEMC_Clusters();
+
+  //-----------------------------
+  // HCAL towering and clustering
+  //-----------------------------
+
+  if (Enable::HCALIN_TOWER) HCALInner_Towers();
+  if (Enable::HCALIN_CLUSTER) HCALInner_Clusters();
+
+  if (Enable::HCALOUT_TOWER) HCALOuter_Towers();
+  if (Enable::HCALOUT_CLUSTER) HCALOuter_Clusters();
+
+  if (Enable::FEMC_TOWER) FEMC_Towers();
+  if (Enable::FEMC_CLUSTER) FEMC_Clusters();
+
+  if (Enable::FHCAL_TOWER) FHCAL_Towers();
+  if (Enable::FHCAL_CLUSTER) FHCAL_Clusters();
+
+  if (Enable::DSTOUT_COMPRESS) ShowerCompress();
+
+  //--------------
+  // SVTX tracking
+  //--------------
+  if (Enable::TRACKING_TRACK)
+  {
+    TrackingInit();
+  }
+
+  if (Enable::MVTX_CLUSTER) Mvtx_Clustering();
+  if (Enable::INTT_CLUSTER) Intt_Clustering();
+  if (Enable::TPC_CLUSTER) TPC_Clustering();
+
+  if (Enable::TRACKING_TRACK)
+  {
+    Tracking_Reco();
+  }
+
+  //--------------
+  // FGEM tracking
+  //--------------
+
+  if (Enable::FGEM_TRACK) FGEM_FastSim_Reco();
+
+  //-----------------
+  // Global Vertexing
+  //-----------------
+  if (Enable::GLOBAL_RECO && Enable::GLOBAL_FASTSIM)
+  {
+    cout << "You can only enable Enable::GLOBAL_RECO or Enable::GLOBAL_FASTSIM, not both" << endl;
+    gSystem->Exit(1);
+  }
+  if (Enable::GLOBAL_RECO)
+  {
+    Global_Reco();
+  }
+  else if (Enable::GLOBAL_FASTSIM)
+  {
+    Global_FastSim();
+  }
+
+  //-----------------
+  // Calo Trigger Simulation
+  //-----------------
+
+  if (Enable::CALOTRIGGER)
+  {
+    CaloTrigger_Sim();
+  }
+
+  //---------
+  // Jet reco
+  //---------
+
+  if (Enable::JETS) Jet_Reco();
+
+  if (Enable::FWDJETS) Jet_FwdReco();
+
+  //----------------------
+  // Simulation evaluation
+  //----------------------
+
+  string outputroot = outputFile;
+  string remove_this = ".root";
+  size_t pos = outputroot.find(remove_this);
+  if (pos != string::npos)
+  {
+    outputroot.erase(pos, remove_this.length());
+  }
+
+  if (Enable::TRACKING_EVAL) Tracking_Eval(outputroot + "g4tracking_eval.root");
+
+  if (Enable::CEMC_EVAL) CEMC_Eval(outputroot + "g4cemc_eval.root");
+
+  if (Enable::HCALIN_EVAL) HCALInner_Eval(outputroot + "g4hcalin_eval.root");
+
+  if (Enable::HCALOUT_EVAL) HCALOuter_Eval(outputroot + "g4hcalout_eval.root");
+
+  if (Enable::FEMC_EVAL) FEMC_Eval(outputroot + "g4femc_eval.root");
+
+  if (Enable::FHCAL_EVAL) FHCAL_Eval(outputroot + "_g4fhcal_eval.root");
+
+  if (Enable::JETS_EVAL) Jet_Eval(outputroot + "g4jet_eval.root");
+
+  if (Enable::FWDJETS_EVAL) Jet_FwdEval(outputroot + "g4fwdjet_eval.root");
+
+  if (Enable::FGEM_EVAL) FGEM_FastSim_Eval(outputroot + "g4tracking_fgem_eval.root");
+
+  if (Enable::DSTREADER) G4DSTreader_fsPHENIX(outputroot + "_DSTReader.root");
+
+  if (Enable::USER) UserAnalysisInit();
+
+  //--------------
+  // Set up Input Managers
+  //--------------
+
+  InputManagers();
+
+  //--------------
+  // Set up Output Managers
+  //--------------
+  if (Enable::PRODUCTION)
+  {
+    Production_CreateOutputDir();
+  }
+
+  if (Enable::DSTOUT)
+  {
+    string FullOutFile = DstOut::OutputDir + "/" + DstOut::OutputFile;
+    Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", FullOutFile);
+    if (Enable::DSTOUT_COMPRESS) DstCompress(out);
+    se->registerOutputManager(out);
+  }
+
+  //-----------------
+  // Event processing
+  //-----------------
+  if (Enable::DISPLAY)
+  {
+    DisplayOn();
+
+    gROOT->ProcessLine("Fun4AllServer *se = Fun4AllServer::instance();");
+    gROOT->ProcessLine("PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");");
+
+    cout << "-------------------------------------------------" << endl;
+    cout << "You are in event display mode. Run one event with" << endl;
+    cout << "se->run(1)" << endl;
+    cout << "Run Geant4 command with following examples" << endl;
+    gROOT->ProcessLine("displaycmd()");
+
+    return 0;
+  }
+
+  // if we use a negative number of events we go back to the command line here
+  if (nEvents < 0)
+  {
+    return 0;
+  }
+  // if we run the particle generator and use 0 it'll run forever
+  if (nEvents == 0 && !Input::HEPMC && !Input::READHITS)
+  {
+    cout << "using 0 for number of events is a bad idea when using particle generators" << endl;
+    cout << "it will run forever, so I just return without running anything" << endl;
+    return 0;
+  }
+
+  se->skip(skip);
+  se->run(nEvents);
+
+  //-----
+  // Exit
+  //-----
+
+  se->End();
+  std::cout << "All done" << std::endl;
+  delete se;
+  if (Enable::PRODUCTION)
+  {
+    Production_MoveOutput();
+  }
+  gSystem->Exit(0);
+  return 0;
+}
+
+void G4Cmd(const char *cmd)
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->ApplyCommand(cmd);
+}
+#endif

--- a/detectors/fsPHENIX/G4Setup_fsPHENIX.C
+++ b/detectors/fsPHENIX/G4Setup_fsPHENIX.C
@@ -1,0 +1,294 @@
+#ifndef MACRO_G4SETUPFSPHENIX_C
+#define MACRO_G4SETUPFSPHENIX_C
+
+#include <GlobalVariables.C>
+
+#include <G4_Bbc.C>
+#include <G4_BlackHole.C>
+#include <G4_CEmc_Spacal.C>
+#include <G4_FEMC.C>
+#include <G4_FGEM_fsPHENIX.C>
+#include <G4_FHCAL.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx.C>
+#include <G4_Pipe.C>
+#include <G4_Piston.C>
+#include <G4_PlugDoor_fsPHENIX.C>
+#include <G4_TPC.C>
+#include <G4_User.C>
+#include <G4_World.C>
+
+#include <g4eval/PHG4DstCompressReco.h>
+
+#include <g4main/PHG4Reco.h>
+#include <g4main/PHG4TruthSubsystem.h>
+
+#include <phfield/PHFieldConfig.h>
+
+#include <fun4all/Fun4AllDstOutputManager.h>
+
+R__LOAD_LIBRARY(libg4decayer.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+
+void ShowerCompress(int verbosity = 0);
+void DstCompress(Fun4AllDstOutputManager *out);
+
+void RunLoadTest() {}
+
+void G4Init()
+{
+  // load detector/material macros and execute Init() function
+
+  if (Enable::PIPE) PipeInit();
+  if (Enable::MVTX) MvtxInit();
+  if (Enable::INTT) InttInit();
+  if (Enable::TPC) TPCInit();
+  if (Enable::BBC) BbcInit();
+  if (Enable::CEMC) CEmcInit();
+  if (Enable::HCALIN) HCalInnerInit();
+  if (Enable::MAGNET) MagnetInit();
+// We want the field - even if the magnet volume is disabled
+  MagnetFieldInit();
+  if (Enable::HCALOUT) HCalOuterInit();
+  if (Enable::FGEM) FGEM_Init();
+  if (Enable::FEMC) FEMCInit();
+  if (Enable::FHCAL) FHCALInit();
+  if (Enable::PISTON) PistonInit();
+  if (Enable::PLUGDOOR) PlugDoorInit();
+  if (Enable::USER) UserInit();
+  if (Enable::BLACKHOLE) BlackHoleInit();
+}
+
+int G4Setup()
+{
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4Reco *g4Reco = new PHG4Reco();
+  g4Reco->save_DST_geometry(true);  //Save geometry from Geant4 to DST
+  WorldInit(g4Reco);
+  g4Reco->set_rapidity_coverage(1.1);  // according to drawings
+  if (G4P6DECAYER::decayType != EDecayType::kAll)
+  {
+    g4Reco->set_force_decay(G4P6DECAYER::decayType);
+  }
+
+  double fieldstrength;
+  istringstream stringline(G4MAGNET::magfield);
+  stringline >> fieldstrength;
+  if (stringline.fail())
+  {  // conversion to double fails -> we have a string
+
+    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos)
+    {
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
+    }
+    else
+    {
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::kField2D);
+    }
+  }
+  else
+  {
+    g4Reco->set_field(fieldstrength);  // use const soleniodal field
+  }
+  g4Reco->set_field_rescale(G4MAGNET::magfield_rescale);
+
+  double radius = 0.;
+
+  //----------------------------------------
+  // PIPE
+  if (Enable::PIPE)
+  {
+    radius = Pipe(g4Reco, radius);
+  }
+  if (Enable::MVTX)
+  {
+    radius = Mvtx(g4Reco, radius);
+  }
+  if (Enable::INTT)
+  {
+    radius = Intt(g4Reco, radius);
+  }
+  if (Enable::TPC)
+  {
+    radius = TPC(g4Reco, radius);
+  }
+
+  //----------------------------------------
+  // BBC
+
+  if (Enable::BBC) Bbc(g4Reco);
+
+  //----------------------------------------
+  // CEMC
+  //
+  if (Enable::CEMC)
+  {
+    radius = CEmc(g4Reco, radius, 8);
+  }
+
+  //----------------------------------------
+  // HCALIN
+
+  if (Enable::HCALIN)
+  {
+    radius = HCalInner(g4Reco, radius, 4);
+  }
+
+  //----------------------------------------
+  // MAGNET
+
+  if (Enable::MAGNET)
+  {
+    radius = Magnet(g4Reco, radius);
+  }
+
+  //----------------------------------------
+  // HCALOUT
+
+  if (Enable::HCALOUT)
+  {
+    radius = HCalOuter(g4Reco, radius, 4);
+  }
+
+  //----------------------------------------
+  // Forward tracking
+
+  if (Enable::FGEM)
+  {
+    FGEMSetup(g4Reco);
+  }
+
+  //----------------------------------------
+  // FEMC
+
+  if (Enable::FEMC)
+  {
+    FEMCSetup(g4Reco);
+  }
+  //----------------------------------------
+  // FHCAL
+
+  if (Enable::FHCAL)
+  {
+    FHCALSetup(g4Reco);
+  }
+  if (Enable::PISTON)
+  {
+    Piston(g4Reco);
+  }
+
+  if (Enable::PLUGDOOR)
+  {
+    PlugDoor(g4Reco);
+  }
+
+  if (Enable::USER)
+  {
+    UserDetector(g4Reco);
+  }
+
+  if (Enable::BLACKHOLE)
+  {
+    BlackHole(g4Reco, radius);
+  }
+
+  PHG4TruthSubsystem *truth = new PHG4TruthSubsystem();
+  g4Reco->registerSubsystem(truth);
+
+  // finally adjust the world size in case the default is too small
+  WorldSize(g4Reco, radius);
+
+  se->registerSubsystem(g4Reco);
+  return 0;
+}
+
+void ShowerCompress(int verbosity = 0)
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4DstCompressReco *compress = new PHG4DstCompressReco("PHG4DstCompressReco");
+  compress->AddHitContainer("G4HIT_PIPE");
+  compress->AddHitContainer("G4HIT_SVTXSUPPORT");
+  compress->AddHitContainer("G4HIT_CEMC_ELECTRONICS");
+  compress->AddHitContainer("G4HIT_CEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_CEMC");
+  compress->AddHitContainer("G4HIT_CEMC_SPT");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN_SPT");
+  compress->AddHitContainer("G4HIT_MAGNET");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALOUT");
+  compress->AddHitContainer("G4HIT_HCALOUT");
+  compress->AddHitContainer("G4HIT_BH_1");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_PLUS");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_NEG");
+  compress->AddCellContainer("G4CELL_CEMC");
+  compress->AddCellContainer("G4CELL_HCALIN");
+  compress->AddCellContainer("G4CELL_HCALOUT");
+  compress->AddTowerContainer("TOWER_SIM_CEMC");
+  compress->AddTowerContainer("TOWER_RAW_CEMC");
+  compress->AddTowerContainer("TOWER_CALIB_CEMC");
+  compress->AddTowerContainer("TOWER_SIM_HCALIN");
+  compress->AddTowerContainer("TOWER_RAW_HCALIN");
+  compress->AddTowerContainer("TOWER_CALIB_HCALIN");
+  compress->AddTowerContainer("TOWER_SIM_HCALOUT");
+  compress->AddTowerContainer("TOWER_RAW_HCALOUT");
+  compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+
+  compress->AddHitContainer("G4HIT_FEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_FEMC");
+  compress->AddHitContainer("G4HIT_FHCAL");
+  compress->AddHitContainer("G4HIT_ABSORBER_FHCAL");
+  compress->AddCellContainer("G4CELL_FEMC");
+  compress->AddCellContainer("G4CELL_FHCAL");
+  compress->AddTowerContainer("TOWER_SIM_FEMC");
+  compress->AddTowerContainer("TOWER_RAW_FEMC");
+  compress->AddTowerContainer("TOWER_CALIB_FEMC");
+  compress->AddTowerContainer("TOWER_SIM_FHCAL");
+  compress->AddTowerContainer("TOWER_RAW_FHCAL");
+  compress->AddTowerContainer("TOWER_CALIB_FHCAL");
+
+  se->registerSubsystem(compress);
+
+  return;
+}
+
+void DstCompress(Fun4AllDstOutputManager *out)
+{
+  if (out)
+  {
+    out->StripNode("G4HIT_PIPE");
+    out->StripNode("G4HIT_SVTXSUPPORT");
+    out->StripNode("G4HIT_CEMC_ELECTRONICS");
+    out->StripNode("G4HIT_CEMC");
+    out->StripNode("G4HIT_ABSORBER_CEMC");
+    out->StripNode("G4HIT_CEMC_SPT");
+    out->StripNode("G4HIT_ABSORBER_HCALIN");
+    out->StripNode("G4HIT_HCALIN");
+    out->StripNode("G4HIT_HCALIN_SPT");
+    out->StripNode("G4HIT_MAGNET");
+    out->StripNode("G4HIT_ABSORBER_HCALOUT");
+    out->StripNode("G4HIT_HCALOUT");
+    out->StripNode("G4HIT_BH_1");
+    out->StripNode("G4HIT_BH_FORWARD_PLUS");
+    out->StripNode("G4HIT_BH_FORWARD_NEG");
+    out->StripNode("G4CELL_CEMC");
+    out->StripNode("G4CELL_HCALIN");
+    out->StripNode("G4CELL_HCALOUT");
+
+    out->StripNode("G4HIT_FEMC");
+    out->StripNode("G4HIT_ABSORBER_FEMC");
+    out->StripNode("G4HIT_FHCAL");
+    out->StripNode("G4HIT_ABSORBER_FHCAL");
+    out->StripNode("G4CELL_FEMC");
+    out->StripNode("G4CELL_FHCAL");
+  }
+}
+#endif

--- a/detectors/fsPHENIX/init_gui_vis.mac
+++ b/detectors/fsPHENIX/init_gui_vis.mac
@@ -1,0 +1,20 @@
+# Macro file for the initialization of example B3
+# in interactive session
+#
+# Set some default verbose
+#
+/control/verbose 2
+/control/saveHistory
+/run/verbose 2
+#
+# Change the default number of threads (in multi-threaded mode)
+#/run/numberOfThreads 4
+#
+# Initialize kernel
+/run/initialize
+#
+# create empty scene
+#
+/vis/scene/create
+# open graphics (opengl QT)
+/vis/open OGL

--- a/detectors/fsPHENIX/vis.mac
+++ b/detectors/fsPHENIX/vis.mac
@@ -1,0 +1,82 @@
+# $Id: vis.mac,v 1.4 2010/04/14 18:32:59 lindenle Exp $
+#
+# Macro file for the initialization phase of "exampleN03.cc"
+# when running in interactive mode
+#
+# Sets some default verbose
+#
+/control/verbose 2
+/control/saveHistory
+/run/verbose 2
+#
+# create empty scene
+#
+/vis/scene/create
+#
+# Create a scene handler for a specific graphics system
+# (Edit the next line(s) to choose another graphic system)
+#
+# Use this open statement to get an .eps and .prim files
+# suitable for viewing in DAWN.
+###/vis/open DAWNFILE
+#
+# Use this open statement instead for OpenGL in immediate mode.
+# OGLIX works on the desktops in 1008 while OGLSX terminates
+# the X server. I've heard similar stories about OGLIX on other
+# machines. You might have to play with it. GEANT prints out a
+# list of available graphics systems at some point.
+#/vis/open OGLIX
+/vis/open OGL 1200x900-0+0
+# increase display limit for more complex detectors
+/vis/ogl/set/displayListLimit 500000
+/vis/viewer/set/viewpointThetaPhi 240 -10
+/vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
+# our world is 4x4 meters, the detector is about 1m across
+# zooming by 4 makes it fill the display
+/vis/viewer/zoom 1.5
+#
+# Use this open statement instead to get a HepRep version 1 file
+# suitable for viewing in WIRED.
+#/vis/open HepRepFile
+#
+# Use this open statement instead to get a HepRep version 2 file
+# suitable for viewing in WIRED.
+#/vis/open HepRepXML
+#
+# Output an empty detector
+/vis/viewer/flush
+#
+# Draw trajectories at end of event, showing trajectory points as
+# markers of size 2 pixels
+/vis/scene/add/trajectories smooth
+/vis/modeling/trajectories/create/drawByCharge
+/vis/modeling/trajectories/drawByCharge-0/default/setDrawStepPts true
+/vis/modeling/trajectories/drawByCharge-0/default/setStepPtsSize 2
+# (if too many tracks cause core dump => /tracking/storeTrajectory 0)
+#
+# To draw gammas only
+#/vis/filtering/trajectories/create/particleFilter
+#/vis/filtering/trajectories/particleFilter-0/add gamma
+#
+# To draw charged particles only
+#/vis/filtering/trajectories/particleFilter-0/invert true
+#
+# Many other options available with /vis/modeling and /vis/filtering.
+# For example, select colour by particle ID
+#/vis/modeling/trajectories/create/drawByParticleID
+#/vis/modeling/trajectories/drawByParticleID-0/set e- red
+# remove low energy stuff
+/vis/filtering/trajectories/create/attributeFilter
+/vis/filtering/trajectories/attributeFilter-0/setAttribute IMag
+/vis/filtering/trajectories/attributeFilter-0/addInterval 2 MeV 1000 GeV
+#
+/vis/scene/endOfEventAction accumulate
+#
+# At end of each run, an automatic flush causes graphical output.
+#/run/beamOn 1
+# When you exit Geant4, you will find a file called scene-0.heprep.zip.
+# Unzipping this will give you three separate HepRep files suitable for
+# viewing in WIRED.
+# The first file will contain just detector geometry.
+# The second file will contain the detector plus one event.
+# The third file will contain the detector plus ten events.


### PR DESCRIPTION
Within this commit all macros which were meant for EIC related detector development were moved from the sPHENIX repo into this one.
- mayor changes in common/ (only additions)
- new directorires detectors/fsPHENIX, detectors/EICDetector
- further adaptation to detectors/Modular & detectors/ModularBeast to include the EHCAL and crossing angles as well as adaptions for the FGEMs & EGEMs

This commit is directly related to: https://github.com/sPHENIX-Collaboration/macros/pull/402