### PR TITLE
fix include paths for new installation dir

### DIFF
--- a/common/G4_DRCALO.C
+++ b/common/G4_DRCALO.C
@@ -6,7 +6,7 @@
 #include <g4calo/RawTowerBuilderDRCALO.h>
 #include <g4calo/RawTowerDigitizer.h>
 
-#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <g4eiccalos/PHG4ForwardCalCellReco.h>
 #include <drcalo/PHG4ForwardDualReadoutSubsystem.h>
 
 #include <g4eval/CaloEvaluator.h>

--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -5,8 +5,8 @@
 
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>
-#include <g4detectors/PHG4CrystalCalorimeterSubsystem.h>
-#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <g4eiccalos/PHG4CrystalCalorimeterSubsystem.h>
+#include <g4eiccalos/PHG4ForwardCalCellReco.h>
 
 #include <g4eval/CaloEvaluator.h>
 
@@ -19,7 +19,7 @@
 #include <fun4all/Fun4AllServer.h>
 
 R__LOAD_LIBRARY(libcalo_reco.so)
-R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4eiccalos.so)
 R__LOAD_LIBRARY(libg4detectors.so)
 R__LOAD_LIBRARY(libg4eval.so)
 

--- a/common/G4_EHCAL.C
+++ b/common/G4_EHCAL.C
@@ -6,8 +6,8 @@
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>
 
-#include <g4detectors/PHG4ForwardCalCellReco.h>
-#include <g4detectors/PHG4ForwardHcalSubsystem.h>
+#include <g4eiccalos/PHG4ForwardCalCellReco.h>
+#include <g4eiccalos/PHG4ForwardHcalSubsystem.h>
 
 #include <g4eval/CaloEvaluator.h>
 

--- a/common/G4_FEMC.C
+++ b/common/G4_FEMC.C
@@ -6,8 +6,8 @@
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>
 
-#include <g4detectors/PHG4ForwardCalCellReco.h>
-#include <g4detectors/PHG4ForwardEcalSubsystem.h>
+#include <g4eiccalos/PHG4ForwardCalCellReco.h>
+#include <g4eiccalos/PHG4ForwardEcalSubsystem.h>
 
 #include <g4eval/CaloEvaluator.h>
 

--- a/common/G4_FEMC_EIC.C
+++ b/common/G4_FEMC_EIC.C
@@ -6,8 +6,8 @@
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>
 
-#include <g4detectors/PHG4ForwardCalCellReco.h>
-#include <g4detectors/PHG4ForwardEcalSubsystem.h>
+#include <g4eiccalos/PHG4ForwardCalCellReco.h>
+#include <g4eiccalos/PHG4ForwardEcalSubsystem.h>
 
 #include <g4eval/CaloEvaluator.h>
 
@@ -21,7 +21,7 @@
 
 R__LOAD_LIBRARY(libcalo_reco.so)
 R__LOAD_LIBRARY(libg4calo.so)
-R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eiccalos.so)
 R__LOAD_LIBRARY(libg4eval.so)
 
 namespace Enable

--- a/common/G4_FHCAL.C
+++ b/common/G4_FHCAL.C
@@ -6,8 +6,8 @@
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>
 
-#include <g4detectors/PHG4ForwardCalCellReco.h>
-#include <g4detectors/PHG4ForwardHcalSubsystem.h>
+#include <g4eiccalos/PHG4ForwardCalCellReco.h>
+#include <g4eiccalos/PHG4ForwardHcalSubsystem.h>
 
 #include <g4eval/CaloEvaluator.h>
 
@@ -21,7 +21,7 @@
 
 R__LOAD_LIBRARY(libcalo_reco.so)
 R__LOAD_LIBRARY(libg4calo.so)
-R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eiccalos.so)
 R__LOAD_LIBRARY(libg4eval.so)
 
 namespace Enable

--- a/common/G4_RICH.C
+++ b/common/G4_RICH.C
@@ -10,7 +10,7 @@
 
 #include <GlobalVariables.C>
 
-#include <g4detectors/PHG4RICHSubsystem.h>
+#include <g4rich/PHG4RICHSubsystem.h>
 
 #include <g4main/PHG4Reco.h>
 


### PR DESCRIPTION
Some include paths for eic detectors still pointed to the old sphenix directories. This PR fixes that, all detector macros should work now