### PR TITLE
use sampling fraction from electron sims for no digitization for CEmc

### DIFF
--- a/common/G4_CEmc_EIC.C
+++ b/common/G4_CEmc_EIC.C
@@ -285,7 +285,8 @@ void CEMC_Towers()
   CemcTowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
   if (G4CEMC::TowerDigi == RawTowerDigitizer::kNo_digitization)
   {
-    CemcTowerCalibration->set_calib_const_GeV_ADC(1.0 / 0.023);  // 2.3% sampling fraction from test beam
+    //  0.039 from electron sims (edep(scintillator)/edep(total)
+    CemcTowerCalibration->set_calib_const_GeV_ADC(1.0 / 0.039); 
   }
   else
   {


### PR DESCRIPTION
This PR fixes a mistake in the sampling fraction for no digitisation. The value from the test beam is not appropriate - the eic cemc is just concentrical layers of tungsten and scintillator, not a spacal like in the test beam.
https://indico.bnl.gov/event/10723/contributions/49304/attachments/34285/55606/sampling_fraction.pptx