### PR TITLE
Add support for additional tracking configurations in the modular detector

### DIFF
--- a/common/G4_Tracking_Modular.C
+++ b/common/G4_Tracking_Modular.C
@@ -27,6 +27,7 @@ namespace Enable
   bool TRACKING = false;
   bool TRACKING_EVAL = false;
   bool TRACKING_EVAL_DETAILED = false;
+  bool TRACKING_INNER = false;
   int TRACKING_VERBOSITY = 0;
 }  // namespace Enable
 
@@ -41,10 +42,16 @@ namespace G4TRACKING
   bool PROJECTION_DRCALO = false;
 }  // namespace G4TRACKING
 
+namespace TRACKING
+{
+  std::string TrackNodeNameInner = "TrackMapInner";
+} // namespace TRACKING
+
 //-----------------------------------------------------------------------------//
 void TrackingInit()
 {
   TRACKING::TrackNodeName = "TrackMap";
+  TRACKING::TrackNodeNameInner = "TrackMapInner";
 }
 //-----------------------------------------------------------------------------//
 void Tracking_Reco(TString specialSetting = "")
@@ -59,23 +66,43 @@ void Tracking_Reco(TString specialSetting = "")
   PHG4TrackFastSim *kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
   kalman->Verbosity(verbosity);
   //  kalman->Smearing(false);
-  if (G4TRACKING::DISPLACED_VERTEX){
-    // do not use truth vertex in the track fitting,
-    // which would lead to worse momentum resolution for prompt tracks
-    // but this allows displaced track analysis including DCA and vertex finding
-    kalman->set_use_vertex_in_fitting(false);
-    kalman->set_vertex_xy_resolution(0);  // do not smear the vertex used in the built-in DCA calculation
-    kalman->set_vertex_z_resolution(0);   // do not smear the vertex used in the built-in DCA calculation
-    kalman->enable_vertexing(true);       // enable vertex finding and fitting
-  } else {
-    // constraint to a primary vertex and use it as part of the fitting level arm
-    kalman->set_use_vertex_in_fitting(true);
-    kalman->set_vertex_xy_resolution(50e-4);
-    kalman->set_vertex_z_resolution(50e-4);
+
+  // Store a list of FastSim objects. This way, we can uniformly access multiple objects,
+  // setting the same objets on each when appropriate.
+  std::vector<PHG4TrackFastSim *> kalmanTrackers = {kalman};
+
+  // Option to perform an additional, separate tracking using only the inner detectors.
+  PHG4TrackFastSim *kalmanInnerTracking = nullptr;
+  if (Enable::TRACKING_INNER) {
+    kalmanInnerTracking = new PHG4TrackFastSim("PHG4TrackFastSimInnerTracking");
+    kalmanInnerTracking->Verbosity(verbosity);
+    //  kalmanInnerTracking->Smearing(false);
+    // Add to the list of trackers so we can uniformly access it as needed.
+    kalmanTrackers.push_back(kalmanInnerTracking);
+  }
+  for (auto k : kalmanTrackers) {
+    if (G4TRACKING::DISPLACED_VERTEX){
+      // do not use truth vertex in the track fitting,
+      // which would lead to worse momentum resolution for prompt tracks
+      // but this allows displaced track analysis including DCA and vertex finding
+      k->set_use_vertex_in_fitting(false);
+      k->set_vertex_xy_resolution(0);  // do not smear the vertex used in the built-in DCA calculation
+      k->set_vertex_z_resolution(0);   // do not smear the vertex used in the built-in DCA calculation
+      k->enable_vertexing(true);       // enable vertex finding and fitting
+    } else {
+      // constraint to a primary vertex and use it as part of the fitting level arm
+      k->set_use_vertex_in_fitting(true);
+      k->set_vertex_xy_resolution(50e-4);
+      k->set_vertex_z_resolution(50e-4);
+    }
   }
 
   kalman->set_sub_top_node_name("TRACKS");
   kalman->set_trackmap_out_name(TRACKING::TrackNodeName);
+  if (Enable::TRACKING_INNER) {
+    kalmanInnerTracking->set_sub_top_node_name("TRACKS");
+    kalmanInnerTracking->set_trackmap_out_name(TRACKING::TrackNodeNameInner);
+  }
 
   //-------------------------
   // Barrel upgrade (LANL)
@@ -95,15 +122,17 @@ void Tracking_Reco(TString specialSetting = "")
     }
   
     for (Int_t i = 0; i < nLayer; i++){
-      kalman->add_phg4hits(Form("G4HIT_BARREL_%d", i),              //      const std::string& phg4hitsNames,
-                          PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
-                          999.,                        //      const float radres, (not used in cylindrical geom)
-                          pitch/sqrt(12),              //      const float phires,
-                          pitch/sqrt(12),              //      const float lonres,
-                          1,                           //      const float eff,
-                          0);                          //      const float noise
-      if (Enable::TRACKING_EVAL_DETAILED){
-        kalman -> add_cylinder_state(Form("BARREL_%d", i), r[i]);
+      for (auto k : kalmanTrackers) {
+        k->add_phg4hits(Form("G4HIT_BARREL_%d", i),              //      const std::string& phg4hitsNames,
+                       PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+                       999.,                        //      const float radres, (not used in cylindrical geom)
+                       pitch/sqrt(12),              //      const float phires,
+                       pitch/sqrt(12),              //      const float lonres,
+                       1,                           //      const float eff,
+                       0);                          //      const float noise
+        if (Enable::TRACKING_EVAL_DETAILED){
+          k->add_cylinder_state(Form("BARREL_%d", i), r[i]);
+        }
       }
     }
   }
@@ -131,15 +160,17 @@ void Tracking_Reco(TString specialSetting = "")
     for (int i = 0; i < nDisks; i++) {
       if (llargerPitch != -1 && i >= llargerPitch)
         pitch           = 36.4e-4;
-      kalman->add_phg4hits(Form("G4HIT_FST_%d", i),           //      const std::string& phg4hitsNames,
-                           PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-                           pitch/sqrt(12),                    //      const float radres,
-                           pitch/sqrt(12),                    //      const float phires,
-                           999.,                              //      const float lonres, number not used in vertical plane geometry
-                           1,                                 //      const float eff,
-                           0);                                //      const float noise
-      if (Enable::TRACKING_EVAL_DETAILED){
-        kalman -> add_zplane_state(Form("FST_%d", i), zFWDdisks[i]);
+      for (auto k : kalmanTrackers) {
+        k->add_phg4hits(Form("G4HIT_FST_%d", i),           //      const std::string& phg4hitsNames,
+                       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+                       pitch/sqrt(12),                    //      const float radres,
+                       pitch/sqrt(12),                    //      const float phires,
+                       999.,                              //      const float lonres, number not used in vertical plane geometry
+                       1,                                 //      const float eff,
+                       0);                                //      const float noise
+        if (Enable::TRACKING_EVAL_DETAILED){
+          k->add_zplane_state(Form("FST_%d", i), zFWDdisks[i]);
+        }
       }
     }
   }
@@ -154,34 +185,39 @@ void Tracking_Reco(TString specialSetting = "")
     float rBarrel[6]  = {3.3, 5.7, 21.0, 22.68, 39.30, 43.23};
     for (int i = 10; i < 16; i++) {
       sprintf(nodename, "G4HIT_LBLVTX_CENTRAL_%d", i);
-      kalman->add_phg4hits(
-          nodename,                    // const std::string& phg4hitsNames
-          PHG4TrackFastSim::Cylinder,  // const DETECTOR_TYPE phg4dettype
-          999.,                        // radial-resolution [cm] (this number is not used in cylindrical geometry)
-          pitch/sqrt(12),                      // azimuthal (arc-length) resolution [cm]
-          pitch/sqrt(12),                      // longitudinal (z) resolution [cm]
-          1,                           // efficiency (fraction)
-          0                            // hit noise
-      );
-      if (Enable::TRACKING_EVAL_DETAILED){
-        kalman -> add_cylinder_state(Form("LBLVTX_CENTRAL_%d", i), rBarrel[i-10]);
+
+      for (auto k : kalmanTrackers) {
+        k->add_phg4hits(
+            nodename,                    // const std::string& phg4hitsNames
+            PHG4TrackFastSim::Cylinder,  // const DETECTOR_TYPE phg4dettype
+            999.,                        // radial-resolution [cm] (this number is not used in cylindrical geometry)
+            pitch/sqrt(12),                      // azimuthal (arc-length) resolution [cm]
+            pitch/sqrt(12),                      // longitudinal (z) resolution [cm]
+            1,                           // efficiency (fraction)
+            0                            // hit noise
+        );
+        if (Enable::TRACKING_EVAL_DETAILED){
+          k->add_cylinder_state(Form("LBLVTX_CENTRAL_%d", i), rBarrel[i-10]);
+        }
       }
     }
     // FORWARD DISKS
     float zFWDdisks[5]  = {25, 49, 73, 97, 121};
     for (int i = 20; i < 25; i++) {
       sprintf(nodename, "G4HIT_LBLVTX_FORWARD_%d", i);
-      kalman->add_phg4hits(
-          nodename,                          // const std::string& phg4hitsNames
-          PHG4TrackFastSim::Vertical_Plane,  // const DETECTOR_TYPE phg4dettype
-          pitch/sqrt(12),                            // radial-resolution [cm]
-          pitch/sqrt(12),                            // azimuthal (arc-length) resolution [cm]
-          999.,                              // longitudinal (z) resolution [cm] (this number is not used in vertical plane geometry)
-          1,                                 // efficiency (fraction)
-          0                                  // hit noise
-      );
-      if (Enable::TRACKING_EVAL_DETAILED){
-        kalman -> add_zplane_state(Form("LBLVTX_FORWARD_%d", i), zFWDdisks[i-20]);
+      for (auto k : kalmanTrackers) {
+        k->add_phg4hits(
+            nodename,                          // const std::string& phg4hitsNames
+            PHG4TrackFastSim::Vertical_Plane,  // const DETECTOR_TYPE phg4dettype
+            pitch/sqrt(12),                            // radial-resolution [cm]
+            pitch/sqrt(12),                            // azimuthal (arc-length) resolution [cm]
+            999.,                              // longitudinal (z) resolution [cm] (this number is not used in vertical plane geometry)
+            1,                                 // efficiency (fraction)
+            0                                  // hit noise
+        );
+        if (Enable::TRACKING_EVAL_DETAILED){
+          k->add_zplane_state(Form("LBLVTX_FORWARD_%d", i), zFWDdisks[i-20]);
+        }
       }
     }
     
@@ -190,17 +226,19 @@ void Tracking_Reco(TString specialSetting = "")
     float zBWDdisks[5]  = {-25, -49, -73, -97, -121};
     for (int i = 30; i < 35; i++) {
       sprintf(nodename, "G4HIT_LBLVTX_BACKWARD_%d", i);
-      kalman->add_phg4hits(
-          nodename,                          // const std::string& phg4hitsNames
-          PHG4TrackFastSim::Vertical_Plane,  // const DETECTOR_TYPE phg4dettype
-          pitch/sqrt(12),                            // radial-resolution [cm]
-          pitch/sqrt(12),                            // azimuthal (arc-length) resolution [cm]
-          999.,                              // longitudinal (z) resolution [cm] (this number is not used in vertical plane geometry)
-          1,                                 // efficiency (fraction)
-          0                                  // hit noise
-      );
-      if (Enable::TRACKING_EVAL_DETAILED){
-        kalman -> add_zplane_state(Form("LBLVTX_BACKWARD_%d", i), zBWDdisks[i-30]);
+      for (auto k : kalmanTrackers) {
+        k->add_phg4hits(
+            nodename,                          // const std::string& phg4hitsNames
+            PHG4TrackFastSim::Vertical_Plane,  // const DETECTOR_TYPE phg4dettype
+            pitch/sqrt(12),                            // radial-resolution [cm]
+            pitch/sqrt(12),                            // azimuthal (arc-length) resolution [cm]
+            999.,                              // longitudinal (z) resolution [cm] (this number is not used in vertical plane geometry)
+            1,                                 // efficiency (fraction)
+            0                                  // hit noise
+        );
+        if (Enable::TRACKING_EVAL_DETAILED){
+          k->add_zplane_state(Form("LBLVTX_BACKWARD_%d", i), zBWDdisks[i-30]);
+        }
       }
     }
   }
@@ -451,7 +489,10 @@ void Tracking_Reco(TString specialSetting = "")
     kalman->add_state_name("EEMC");
   }
 
-  se->registerSubsystem(kalman);
+
+  for (auto k : kalmanTrackers) {
+    se->registerSubsystem(k);
+  }
   return;
 }
 

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -278,9 +278,12 @@ int Fun4All_G4_FullDetectorModular(
 
   Enable::TRACKING = true;
   Enable::TRACKING_EVAL = Enable::TRACKING && true;
+  if (specialSetting.Contains("INNERTRACKING")) {
+    Enable::TRACKING_INNER = true;
+  }
   if (specialSetting.Contains("TREXTOUT"))
     Enable::TRACKING_EVAL_DETAILED = Enable::TRACKING_EVAL && true;
-  
+
   G4TRACKING::DISPLACED_VERTEX = true;  // this option exclude vertex in the track fitting and use RAVE to reconstruct primary and 2ndary vertexes
                                          // projections to calorimeters
                                          


### PR DESCRIPTION
By default, only the standard tracking configuration is enabled.

When enabled, it currently allows for tracking using all detectors, as well as the inner only. Other options could be added fairly easily. This takes advantage of the functionality added to the event evaluator in https://github.com/sPHENIX-Collaboration/coresoftware/pull/1174

@FriederikeBock 