### PR TITLE
fixed a bunch of issues in G4_GEM_EIC.C, adjusted G4_Tracking_EIC.C for different number of egems

### DIFF
--- a/common/G4_GEM_EIC.C
+++ b/common/G4_GEM_EIC.C
@@ -17,7 +17,7 @@ void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
 namespace Enable
 {
   bool EGEM = false;
-  bool EGEM_FULL = true;
+  bool EGEM_FULL = false;
   bool FGEM = false;
   bool FGEM_ORIG = false;
 }  // namespace Enable
@@ -43,15 +43,22 @@ void EGEMSetup(PHG4Reco *g4Reco)
    * Geometric constraints:
    * TPC length = 211 cm --> from z = -105.5 to z = +105.5
    */
+  if (Enable::EGEM && Enable::EGEM_FULL)
+  {
+    cout << "EGEM and EGEM_FULL cannot be enabled simultaneously" << endl;
+  }
   float thickness = 3.;
-  if (Enable::EGEM_FULL){
+  if (Enable::EGEM)
+  {
+    make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
+    make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);
+  }
+  if (Enable::EGEM_FULL)
+  {
     make_GEM_station("EGEM_0", g4Reco, -20.5 + thickness, -0.94, -1.95);
     make_GEM_station("EGEM_1", g4Reco, -69.5 + thickness, -2.07, -3.21);
     make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
     make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);
-  } else {
-    make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
-    make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);    
   }
 }
 
@@ -66,19 +73,23 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
   PHG4SectorSubsystem *gem;
 
   ///////////////////////////////////////////////////////////////////////////
-  if(Enable::FGEM_ORIG){
+  if (Enable::FGEM_ORIG)
+  {
     make_GEM_station("FGEM_0", g4Reco, 17.5, 0.94, 1.95, N_Sector);
     make_GEM_station("FGEM_1", g4Reco, 66.5, 2.07, 3.20, N_Sector);
   }
   ///////////////////////////////////////////////////////////////////////////
-  if(Enable::FGEM_ORIG){
+  if (Enable::FGEM_ORIG)
+  {
     etamax = 3.3;
-  } else {
+  }
+  else
+  {
     etamax = 2;
   }
   make_GEM_station("FGEM_2", g4Reco, 134.0, min_eta, etamax, N_Sector);
   ///////////////////////////////////////////////////////////////////////////
-  make_GEM_station("FGEM_3_LowerEta", g4Reco, 157.0, min_eta, 3.3, N_Sector, tilt, true);
+  make_GEM_station("FGEM_3", g4Reco, 157.0, min_eta, 3.3, N_Sector, tilt, true);
 
   ///////////////////////////////////////////////////////////////////////////
   make_GEM_station("FGEM_4", g4Reco, 271.0, 2, 3.5, N_Sector);
@@ -86,14 +97,15 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
 }
 
 // ======================================================================================================================
-void addPassiveMaterial(PHG4Reco *g4Reco){
+void addPassiveMaterial(PHG4Reco *g4Reco)
+{
   float z_pos = 130.0;
 
   // This is a mockup calorimeter in the forward (hadron-going) direction
-  PHG4CylinderSubsystem *cyl_f = new PHG4CylinderSubsystem("CALO_FORWARD_PASSIVE",0);
-  cyl_f->set_double_param("length", 5);		// Length in z direction in cm
-  cyl_f->set_double_param("radius", z_pos*0.0503-0.180808); // beampipe needs to fit here
-  cyl_f->set_double_param("thickness", 43); // 
+  PHG4CylinderSubsystem *cyl_f = new PHG4CylinderSubsystem("CALO_FORWARD_PASSIVE", 0);
+  cyl_f->set_double_param("length", 5);                          // Length in z direction in cm
+  cyl_f->set_double_param("radius", z_pos * 0.0503 - 0.180808);  // beampipe needs to fit here
+  cyl_f->set_double_param("thickness", 43);                      //
   cyl_f->set_string_param("material", "G4_Al");
   cyl_f->set_double_param("place_z", z_pos);
   //cyl_f->SetActive(1);
@@ -101,12 +113,11 @@ void addPassiveMaterial(PHG4Reco *g4Reco){
   //cyl_f->set_color(0,1,1,0.3); //reddish
   g4Reco->registerSubsystem(cyl_f);
 
-  
   // This is a mockup calorimeter in the backward (electron-going) direction
-  PHG4CylinderSubsystem * cyl_b = new PHG4CylinderSubsystem("CALO_BACKWARD_PASSIVE",0);
-  cyl_b->set_double_param("length", 5);	// Length in z direction in cm
-  cyl_b->set_double_param("radius",abs(-z_pos*0.030-0.806));	// beampipe needs to fit here
-  cyl_b->set_double_param("thickness", 43); // 
+  PHG4CylinderSubsystem *cyl_b = new PHG4CylinderSubsystem("CALO_BACKWARD_PASSIVE", 0);
+  cyl_b->set_double_param("length", 5);                            // Length in z direction in cm
+  cyl_b->set_double_param("radius", abs(-z_pos * 0.030 - 0.806));  // beampipe needs to fit here
+  cyl_b->set_double_param("thickness", 43);                        //
   cyl_b->set_string_param("material", "G4_Al");
   cyl_b->set_double_param("place_z", -z_pos);
   //cyl_b->SetActive(1);
@@ -150,33 +161,41 @@ int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
 
   double polar_angle = 0;
 
-  if (doTilt){
+  if (doTilt)
+  {
     zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt)) * sin(tilt);
-  } else {  
-    if (zpos < 0){
+  }
+  else
+  {
+    if (zpos < 0)
+    {
       zpos = -zpos;
       polar_angle = M_PI;
-    }    
-  }
-  if (etamax < etamin){
-      double t = etamax;
-      etamax = etamin;
-      etamin = t;
     }
+  }
+  if (etamax < etamin)
+  {
+    double t = etamax;
+    etamax = etamin;
+    etamin = t;
+  }
 
   PHG4SectorSubsystem *gem;
   gem = new PHG4SectorSubsystem(name);
 
   gem->SuperDetector(name);
 
-  if (doTilt){
+  if (doTilt)
+  {
     gem->get_geometry().set_normal_polar_angle((PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax)) / 2);
-    gem->get_geometry().set_normal_start( zpos * PHG4Sector::Sector_Geometry::Unit_cm(), PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
-  } else {
+    gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm(), PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  }
+  else
+  {
     gem->get_geometry().set_normal_polar_angle(polar_angle);
     gem->get_geometry().set_normal_start(zpos * PHG4Sector::Sector_Geometry::Unit_cm());
   }
-  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));  
+  gem->get_geometry().set_min_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
   gem->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
@@ -186,15 +205,9 @@ int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
 
   AddLayers_MiniTPCDrift(gem);
   gem->get_geometry().AddLayers_HBD_GEM();
-  g4Reco->registerSubsystem(gem);
-  
-  
-  AddLayers_MiniTPCDrift(gem);
-  gem->get_geometry().AddLayers_HBD_GEM();
   gem->OverlapCheck(Enable::OVERLAPCHECK);
   g4Reco->registerSubsystem(gem);
 
-  
   return 0;
 }
 #endif

--- a/common/G4_Tracking_EIC.C
+++ b/common/G4_Tracking_EIC.C
@@ -95,7 +95,7 @@ void Tracking_Reco()
       for (int n = 0; n < 2; n++)
       {
         if (n == 1) pitch = 36.4e-4 / sqrt(12);
-        for (int i=0; i < nLayer[n]; i++)
+        for (int i = 0; i < nLayer[n]; i++)
         {
           kalman->add_phg4hits(Form("G4HIT_BARREL%d_%d", n, i),  // const std::string& phg4hitsNames,
                                PHG4TrackFastSim::Cylinder,       // const DETECTOR_TYPE phg4dettype,
@@ -111,7 +111,7 @@ void Tracking_Reco()
     {
       int nLayer = 5;
       if (G4BARREL::SETTING::BARRELV4) nLayer = 6;
-      for (int i=0; i < nLayer; i++)
+      for (int i = 0; i < nLayer; i++)
       {
         kalman->add_phg4hits(Form("G4HIT_BARREL_%d", i),  // const std::string& phg4hitsNames,
                              PHG4TrackFastSim::Cylinder,  // const DETECTOR_TYPE phg4dettype,
@@ -157,10 +157,15 @@ void Tracking_Reco()
   //-------------------------
   // EGEM
   //-------------------------
-  if (Enable::EGEM)
+  if (Enable::EGEM || Enable::EGEM_FULL)
   {
+    int first_gem = 0;
+    if (Enable::EGEM)
+    {
+      first_gem = 2;
+    }
     // GEM, 70um azimuthal resolution, 1cm radial strips
-    for (int i = 0; i < 4; i++)
+    for (int i = first_gem; i < 4; i++)
     {
       kalman->add_phg4hits(
           Form("G4HIT_EGEM_%d", i),          //      const std::string& phg4hitsNames,


### PR DESCRIPTION
The G4_GEM_EIC registered every GEM twice (code duplication at the end of the macro) which then crashed the cleanup run at the end of processing. It renamed FGEM_3 to FGEM_3_LowerEta which crashed the tracking (those volume names are used to set node names). There is still an FGEM_4_LowerEta volume but since an FGEM_4 volume is created this does not crash the tracking (but the lowereta volume is not part of any tracking either). EGEM_FULL was enabled by default (we must not do that, all should be disabled by default - with very rare exceptions), so macros which just enabled EGEM were in trouble. The G4_Tracking_EIC.C looped over the wrong number of EGEMs, there are now two hardcoded cases (that should be changed to read the config off the G4_GEM_EIC.C, not make it's own if's