### PR TITLE
adaptations for Modular detector & calibration changes for LFHCAL & FEMC

### DIFF
--- a/common/G4_DIRC.C
+++ b/common/G4_DIRC.C
@@ -126,8 +126,12 @@ double DIRCSetup(PHG4Reco *g4Reco)
   // simple approximation for DIRC prism
   PHG4ConeSubsystem *cone = new PHG4ConeSubsystem("DIRC_Prism");
   cone->set_color(0, 1, 0);
+//   cone->SetR1(radiator_R, radiator_R + 20);
+//   cone->SetR2(radiator_R, radiator_R + 2);
+
   cone->SetR1(radiator_R, radiator_R + 20);
   cone->SetR2(radiator_R, radiator_R + 2);
+
   cone->SetZlength(0.5 * G4DIRC::z_prism);
   cone->SetPlaceZ(G4DIRC::z_start - 0.5 * G4DIRC::z_prism);
   cone->SetMaterial("Quartz");

--- a/common/G4_FEMC_EIC.C
+++ b/common/G4_FEMC_EIC.C
@@ -272,7 +272,10 @@ void FEMC_Towers()
   TowerCalibration2->TowerType(2);
   TowerCalibration2->Verbosity(verbosity);
   TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration2->set_calib_const_GeV_ADC(1.0 / 0.249);  // sampling fraction = 0.249 for e-
+  if (G4FEMC::SETTING::readoutsplit)
+    TowerCalibration2->set_calib_const_GeV_ADC(1.0 / (0.249*0.84));  // sampling fraction = 0.249 for e-
+  else 
+    TowerCalibration2->set_calib_const_GeV_ADC(1.0 / 0.249);  // sampling fraction = 0.249 for e-
   TowerCalibration2->set_pedstal_ADC(0);
   se->registerSubsystem(TowerCalibration2);
 

--- a/common/G4_HCalIn_EIC.C
+++ b/common/G4_HCalIn_EIC.C
@@ -138,8 +138,9 @@ double HCalInner(PHG4Reco *g4Reco,
   //     close to cryostat. 
 
   if (!G4HCALIN::SETTING::USECEMCGeo){
+    cout << "Setting up with inner HCAL for BECAL setup" << endl;
     double z_end = G4HCALIN::support_ring_z_ring2 - 12.5 + (G4HCALIN::dz/2.0);
-    double z_start = -287-30; // DIRC prizm beginning
+    double z_start = -287; // DIRC prizm beginning
     double length = z_end - z_start;
     double z_shift = 0.5 * (z_end + z_start);
 

--- a/common/G4_LFHCAL.C
+++ b/common/G4_LFHCAL.C
@@ -90,7 +90,7 @@ TString GetMappingFile(){
   else if (G4LFHCAL::SETTING::asymmetric)
   {
     if (G4LFHCAL::SETTING::longer)
-      mappinFileName += "/LFHcal/mapping/towerMap_LFHCAL_asymmetric.txt";
+      mappinFileName += "/LFHcal/mapping/towerMap_LFHCAL_asymmetric-long.txt";
     else 
       mappinFileName += "/LFHcal/mapping/towerMap_LFHCAL_asymmetric.txt";
       
@@ -136,8 +136,11 @@ void LFHCALSetup(PHG4Reco *g4Reco)
   PHG4LFHcalSubsystem *fhcal = new PHG4LFHcalSubsystem("LFHCAL");
 
   TString mapping_fhcal = GetMappingFile();
-  cout << mapping_fhcal.Data() << endl;
-  fhcal->SetTowerMappingFile(mapping_fhcal);
+  cout << "LFHCAL: "<< mapping_fhcal.Data() << endl;
+  ostringstream mapping_fhcal_s;
+  mapping_fhcal_s << mapping_fhcal.Data();
+  
+  fhcal->SetTowerMappingFile(mapping_fhcal_s.str());
   fhcal->OverlapCheck(OverlapCheck);
   fhcal->SetActive();
   fhcal->SetDetailed(true);
@@ -161,11 +164,13 @@ void LFHCAL_Towers()
   // Switch to desired calo setup;
   // PSD like HCal Fe-Scint with doubled granularity  
   TString mapping_fhcal = GetMappingFile();
+  ostringstream mapping_fhcal_s;
+  mapping_fhcal_s << mapping_fhcal.Data();
 
   RawTowerBuilderByHitIndexLHCal *tower_LFHCAL = new RawTowerBuilderByHitIndexLHCal("TowerBuilder_LFHCAL");
   tower_LFHCAL->Detector("LFHCAL");
   tower_LFHCAL->set_sim_tower_node_prefix("SIM");
-  tower_LFHCAL->GeometryTableFile(mapping_fhcal);
+  tower_LFHCAL->GeometryTableFile(mapping_fhcal_s.str());
 
   se->registerSubsystem(tower_LFHCAL);
 
@@ -181,7 +186,7 @@ void LFHCAL_Towers()
   TowerCalibration->Detector("LFHCAL");
   TowerCalibration->Verbosity(verbosity);
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(1. / 0.03898);  // calibrated with muons
+  TowerCalibration->set_calib_const_GeV_ADC(1. / (0.03898*0.93));  // temporary factor 0.93 to fix calibration for new tower design
   TowerCalibration->set_pedstal_ADC(0);
   se->registerSubsystem(TowerCalibration);
 }

--- a/common/G4_LFHCAL.C
+++ b/common/G4_LFHCAL.C
@@ -57,11 +57,64 @@ namespace G4LFHCAL
     bool asymmetric = false;
     bool wDR = false;
     bool FwdSquare = false;
+    bool longer = false;
   }  // namespace SETTING
 }  // namespace G4LFHCAL
 
+TString GetMappingFile(){
+  TString mappinFileName = getenv("CALIBRATIONROOT");
+  if (G4LFHCAL::SETTING::HC2x )
+  {
+    if (G4LFHCAL::SETTING::longer)
+      mappinFileName += "/LFHcal/mapping/towerMap_LFHCAL_2x-long.txt";
+    else 
+      mappinFileName +=  "/LFHcal/mapping/towerMap_LFHCAL_2x.txt";
+  }
+  // HCal Fe-Scint surrounding dual readout calorimeter R>50cm
+  else if (G4LFHCAL::SETTING::wDR)
+  {
+    if (G4LFHCAL::SETTING::longer)
+      mappinFileName +=  "/LFHcal/mapping/towerMap_LFHCAL_wDR-long.txt";
+    else 
+      mappinFileName +=  "/LFHcal/mapping/towerMap_LFHCAL_wDR.txt";
+  }
+  // HCal Fe-Scint surrounding dual readout calorimeter R>50cm
+  else if (G4LFHCAL::SETTING::FwdSquare)
+  {
+    if (G4LFHCAL::SETTING::longer)
+      mappinFileName += "/LFHcal/mapping/towerMap_LFHCAL_FwdSquare-long.txt";
+    else 
+      mappinFileName += "/LFHcal/mapping/towerMap_LFHCAL_FwdSquare.txt";
+  }
+  // full HCal Fe-Scint with asymmetric centering around beampipe
+  else if (G4LFHCAL::SETTING::asymmetric)
+  {
+    if (G4LFHCAL::SETTING::longer)
+      mappinFileName += "/LFHcal/mapping/towerMap_LFHCAL_asymmetric.txt";
+    else 
+      mappinFileName += "/LFHcal/mapping/towerMap_LFHCAL_asymmetric.txt";
+      
+  }
+  //  PSD like HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+  {
+    if (G4LFHCAL::SETTING::longer)
+      mappinFileName +=  "/LFHcal/mapping/towerMap_LFHCAL_default-long.txt";
+    else
+      mappinFileName +=  "/LFHcal/mapping/towerMap_LFHCAL_default.txt";
+  }
+
+  return mappinFileName;
+  
+}
+
+
 void LFHCALInit()
 {
+  if (G4LFHCAL::SETTING::longer){
+    G4LFHCAL::Gz0 = 420;
+    G4LFHCAL::Gdz = 140;
+  }
   // simple way to check if only 1 of the settings is true
   if ((G4LFHCAL::SETTING::FullEtaAcc ? 1 : 0) + (G4LFHCAL::SETTING::HC2x ? 1 : 0) > 1)
   {
@@ -82,37 +135,9 @@ void LFHCALSetup(PHG4Reco *g4Reco)
   /** Use dedicated LFHCAL module */
   PHG4LFHcalSubsystem *fhcal = new PHG4LFHcalSubsystem("LFHCAL");
 
-  ostringstream mapping_fhcal;
-
-  // Switch to desired calo setup;
-  // PSD like HCal Fe-Scint with doubled granularity  
-  if (G4LFHCAL::SETTING::HC2x )
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_2x.txt";
-  }
-  // HCal Fe-Scint surrounding dual readout calorimeter R>50cm
-  else if (G4LFHCAL::SETTING::wDR)
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_wDR.txt";
-  }
-  // HCal Fe-Scint surrounding dual readout calorimeter R>50cm
-  else if (G4LFHCAL::SETTING::FwdSquare)
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_FwdSquare.txt";
-  }
-  // full HCal Fe-Scint with asymmetric centering around beampipe
-  else if (G4LFHCAL::SETTING::asymmetric)
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_asymmetric.txt";
-  }
-  //  PSD like HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
-  else
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_default.txt";
-  }
-
-
-  fhcal->SetTowerMappingFile(mapping_fhcal.str());
+  TString mapping_fhcal = GetMappingFile();
+  cout << mapping_fhcal.Data() << endl;
+  fhcal->SetTowerMappingFile(mapping_fhcal);
   fhcal->OverlapCheck(OverlapCheck);
   fhcal->SetActive();
   fhcal->SetDetailed(true);
@@ -133,39 +158,14 @@ void LFHCAL_Towers()
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  ostringstream mapping_fhcal;
-
   // Switch to desired calo setup;
   // PSD like HCal Fe-Scint with doubled granularity  
-  if (G4LFHCAL::SETTING::HC2x )
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_2x.txt";
-  }
-  // HCal Fe-Scint surrounding dual readout calorimeter R>50cm
-  else if (G4LFHCAL::SETTING::wDR)
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_wDR.txt";
-  }
-  // HCal Fe-Scint surrounding dual readout calorimeter R>50cm
-  else if (G4LFHCAL::SETTING::FwdSquare)
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_FwdSquare.txt";
-  }
-  // full HCal Fe-Scint with asymmetric centering around beampipe
-  else if (G4LFHCAL::SETTING::asymmetric)
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_asymmetric.txt";
-  }
-  //  PSD like HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
-  else
-  {
-    mapping_fhcal << getenv("CALIBRATIONROOT") << "/LFHcal/mapping/towerMap_LFHCAL_default.txt";
-  }
+  TString mapping_fhcal = GetMappingFile();
 
   RawTowerBuilderByHitIndexLHCal *tower_LFHCAL = new RawTowerBuilderByHitIndexLHCal("TowerBuilder_LFHCAL");
   tower_LFHCAL->Detector("LFHCAL");
   tower_LFHCAL->set_sim_tower_node_prefix("SIM");
-  tower_LFHCAL->GeometryTableFile(mapping_fhcal.str());
+  tower_LFHCAL->GeometryTableFile(mapping_fhcal);
 
   se->registerSubsystem(tower_LFHCAL);
 

--- a/common/G4_Pipe_EIC_simple.C
+++ b/common/G4_Pipe_EIC_simple.C
@@ -1,0 +1,143 @@
+#ifndef MACRO_G4PIPEEIC_C
+#define MACRO_G4PIPEEIC_C
+
+#include <GlobalVariables.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4GDMLSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <TSystem.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+// This creates the Enable Flag to be used in the main steering macro
+namespace Enable
+{
+  bool PIPE = false;
+  bool PIPE_ABSORBER = false;
+  bool PIPE_OVERLAPCHECK = false;
+  int PIPE_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4PIPE
+{
+  // Central pipe dimension
+  // Extracted via mechanical model: Detector chamber 3-20-20
+  // directly implimenting the central Be section in G4 cylinder for max speed simulation in the detector region.
+  // The jointer lip structure of the pipe R = 3.2cm x L=5mm is ignored here
+  double be_pipe_radius = 3.1000;
+  double be_pipe_thickness = 3.1762 - be_pipe_radius;  // 760 um for sPHENIX
+  double be_pipe_length_plus = 66.8;                   // +z beam pipe extend.
+  double be_pipe_length_neg = -79.8;                   // -z beam pipe extend.
+  bool use_forward_pipes = true;
+}  // namespace G4PIPE
+
+void PipeInit()
+{
+  if (G4PIPE::use_forward_pipes)
+  {
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 23.);
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 450.);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -463.);
+  }
+  else
+  {
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4PIPE::be_pipe_radius + G4PIPE::be_pipe_thickness);
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4PIPE::be_pipe_length_plus);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, G4PIPE::be_pipe_length_neg);
+  }
+}
+
+//! construct beam pipe
+double Pipe(PHG4Reco* g4Reco,
+            double radius)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::PIPE_ABSORBER;
+  bool OverlapCheck = Enable::PIPE_OVERLAPCHECK;  // detach from Enable::OVERLAPCHECK ||  to suppress GDML validation messages
+  int verbosity = std::max(Enable::VERBOSITY, Enable::PIPE_VERBOSITY);
+  // process pipe extentions?
+  const bool do_pipe_hadron_forward_extension = G4PIPE::use_forward_pipes && true;
+  const bool do_pipe_electron_forward_extension = G4PIPE::use_forward_pipes && true;
+
+  const double be_pipe_length = G4PIPE::be_pipe_length_plus - G4PIPE::be_pipe_length_neg;  // pipe length
+  const double be_pipe_center = 0.5 * (G4PIPE::be_pipe_length_plus + G4PIPE::be_pipe_length_neg);
+
+  if (radius > G4PIPE::be_pipe_radius)
+  {
+    cout << "inconsistency: radius: " << radius
+         << " larger than pipe inner radius: " << G4PIPE::be_pipe_radius << endl;
+    gSystem->Exit(-1);
+  }
+
+  // mid-rapidity beryillium pipe
+  PHG4CylinderSubsystem* cyl = new PHG4CylinderSubsystem("VAC_BE_PIPE", 0);
+  cyl->set_double_param("radius", 0.0);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", be_pipe_length);
+  cyl->set_double_param("place_z", be_pipe_center);
+  cyl->set_string_param("material", "G4_Galactic");
+  cyl->set_double_param("thickness", G4PIPE::be_pipe_radius);
+  cyl->SuperDetector("PIPE");
+  cyl->OverlapCheck(OverlapCheck);
+  if (AbsorberActive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  cyl = new PHG4CylinderSubsystem("BE_PIPE", 1);
+  cyl->set_double_param("radius", G4PIPE::be_pipe_radius);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", be_pipe_length);
+  cyl->set_double_param("place_z", be_pipe_center);
+  cyl->set_string_param("material", "G4_Be");
+  cyl->set_double_param("thickness", G4PIPE::be_pipe_thickness);
+  cyl->SuperDetector("PIPE");
+  cyl->OverlapCheck(OverlapCheck);
+  if (AbsorberActive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  radius = G4PIPE::be_pipe_radius + G4PIPE::be_pipe_thickness;
+
+  radius += no_overlapp;
+
+  if (do_pipe_electron_forward_extension)
+  {
+    if (Enable::IP6)
+    {
+      PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("ElectronForwardEnvelope");
+      gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector_chamber_3-20-20.G4Import.v2.gdml");
+      gdml->set_string_param("TopVolName", "ElectronForwardEnvelope");
+      gdml->set_double_param("rot_z", 180); // flip crossing sign convension after July-2021
+      gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+      gdml->OverlapCheck(OverlapCheck);
+      g4Reco->registerSubsystem(gdml);
+    }
+    if (Enable::IP8)
+    {
+      cout <<__PRETTY_FUNCTION__<<" IP8 beam chamber not defined yet! Consider disable G4PIPE::use_forward_pipes"<<endl;
+      exit(1);
+    }
+  }
+
+  if (do_pipe_hadron_forward_extension)
+  {
+    if (Enable::IP6)
+    {
+      PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardEnvelope");
+      gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector_chamber_3-20-20.G4Import.v2.gdml");
+      gdml->set_string_param("TopVolName", "HadronForwardEnvelope");
+      gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+      gdml->set_double_param("rot_z", 180); // flip crossing sign convension after July-2021
+      gdml->OverlapCheck(OverlapCheck);
+      g4Reco->registerSubsystem(gdml);
+    }
+    if (Enable::IP8)
+    {
+      cout <<__PRETTY_FUNCTION__<<" IP8 beam chamber not defined yet! Consider disable G4PIPE::use_forward_pipes"<<endl;
+      exit(1);
+    }
+  }
+
+  return radius;
+}
+#endif

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -125,8 +125,17 @@ int Fun4All_G4_FullDetectorModular(
                                                                               PHG4SimpleEventGenerator::Uniform);
     INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
     INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
+<<<<<<< HEAD
     // INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-3.5, -1.5);
     INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(1.4, 4.0);
+=======
+    if (generatorSettings.Contains("central"))
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-1.8, 1.2);
+    else if (generatorSettings.Contains("bck"))
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-4, -1.7);
+    else 
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(1.1, 4.0);
+>>>>>>> added option for longer lfhcal
     INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
     INPUTGENERATOR::SimpleEventGenerator[0]->set_p_range(particlemomMin, particlemomMax);
   }
@@ -242,8 +251,8 @@ int Fun4All_G4_FullDetectorModular(
   // EIC beam pipe extension beyond the Be-section:
   G4PIPE::use_forward_pipes = true;
   //EIC hadron far forward magnets and detectors. IP6 and IP8 are incompatible (pick either or);
-  Enable::HFARFWD_MAGNETS = true;
-  Enable::HFARFWD_VIRTUAL_DETECTORS = true;
+  Enable::HFARFWD_MAGNETS = false;
+  Enable::HFARFWD_VIRTUAL_DETECTORS = false;
 
   // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   // geometry - tracking
@@ -454,14 +463,36 @@ int Fun4All_G4_FullDetectorModular(
       Enable::FEMC = true;
     if(specialSetting.Contains("FHCAL") && !specialSetting.Contains("LFHCAL"))
       Enable::FHCAL = true;
-    if(specialSetting.Contains("FWDCALO")){
-      Enable::FEMC = true;
-      Enable::FHCAL = true;
-    }
     if(specialSetting.Contains("LFHCAL"))
       Enable::LFHCAL = true;
     if(specialSetting.Contains("BECAL"))
       Enable::BECAL = true;
+    if(specialSetting.Contains("EHCAL"))
+      Enable::EHCAL = true;
+    if(specialSetting.Contains("EEMCH"))
+      Enable::EEMCH = true;
+    if(specialSetting.Contains("CHCAL")){
+      Enable::HCALIN   = true;
+      Enable::HCALOUT  = true;
+    }
+      
+    if(specialSetting.Contains("FWDCALO")){
+      Enable::FEMC    = true;
+      Enable::FHCAL   = true;
+
+    if(specialSetting.Contains("FWDLCALO")){
+      Enable::FEMC    = true;
+      Enable::LFHCAL  = true;
+    }
+    if(specialSetting.Contains("BARCALO")){
+      Enable::BECAL    = true;
+      Enable::HCALIN   = true;
+      Enable::HCALOUT  = true;
+    }
+    if(specialSetting.Contains("BCKCALO")){
+      Enable::EHCAL    = true;
+      Enable::EEMCH    = true;
+    }
     if(specialSetting.Contains("TTL")){
       // Enable::PIPE = true;
       // G4PIPE::use_forward_pipes = true;
@@ -884,7 +915,8 @@ void ParseTString(TString &specialSetting)
   }
   if (specialSetting.Contains("XDEPTH")) // common for FHCAL and FEMC
   {
-    G4FHCAL::SETTING::extradepth = Enable::FHCAL && true;
+    G4FHCAL::SETTING::extradepth  = Enable::FHCAL && true;
+    G4FHCAL::SETTING::longer      = Enable::LFHCAL && true;
   }
   if (specialSetting.Contains("wDR")) // common for FHCAL and FEMC
   {
@@ -909,6 +941,7 @@ void ParseTString(TString &specialSetting)
     G4FEMC::SETTING::FwdSquare = Enable::FEMC &&true;
     G4TTL::SETTING::optionDR = 1;
   }
+  
   if (specialSetting.Contains("HC2x"))
   {
     G4FHCAL::SETTING::HC2x = true;

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -454,7 +454,7 @@ int Fun4All_G4_FullDetectorModular(
       Enable::FEMC = true;
     if(specialSetting.Contains("FHCAL") && !specialSetting.Contains("LFHCAL"))
       Enable::FHCAL = true;
-    if(specialSetting.Contains("CALO")){
+    if(specialSetting.Contains("FWDCALO")){
       Enable::FEMC = true;
       Enable::FHCAL = true;
     }

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -125,17 +125,12 @@ int Fun4All_G4_FullDetectorModular(
                                                                               PHG4SimpleEventGenerator::Uniform);
     INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
     INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
-<<<<<<< HEAD
-    // INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-3.5, -1.5);
-    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(1.4, 4.0);
-=======
     if (generatorSettings.Contains("central"))
       INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-1.8, 1.2);
     else if (generatorSettings.Contains("bck"))
       INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-4, -1.7);
     else 
       INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(1.1, 4.0);
->>>>>>> added option for longer lfhcal
     INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
     INPUTGENERATOR::SimpleEventGenerator[0]->set_p_range(particlemomMin, particlemomMax);
   }
@@ -332,7 +327,7 @@ int Fun4All_G4_FullDetectorModular(
     Enable::BECAL = true;
     // need to switch of CEMC & HCALin
     Enable::CEMC    = false;
-    Enable::HCALIN  = false; // for now deactivated due to crash
+    Enable::HCALIN  = true; // for now deactivated due to crash
   }
   Enable::MAGNET = true;
 
@@ -453,6 +448,12 @@ int Fun4All_G4_FullDetectorModular(
     Enable::FTTL = false;
     Enable::CTTL = false;
     Enable::ETTL = false;
+    if(specialSetting.Contains("PIPE")){
+      Enable::PIPE = true;
+      G4PIPE::use_forward_pipes = true;    
+    }
+    if(specialSetting.Contains("Magnet"))
+      Enable::MAGNET = true;
     if(specialSetting.Contains("ALLSILICON"))
       Enable::ALLSILICON = true;
     if(specialSetting.Contains("CEMC"))
@@ -475,11 +476,13 @@ int Fun4All_G4_FullDetectorModular(
       Enable::HCALIN   = true;
       Enable::HCALOUT  = true;
     }
-      
+    if(specialSetting.Contains("DIRC"))
+      Enable::DIRC = true;
+    
     if(specialSetting.Contains("FWDCALO")){
       Enable::FEMC    = true;
       Enable::FHCAL   = true;
-
+    }
     if(specialSetting.Contains("FWDLCALO")){
       Enable::FEMC    = true;
       Enable::LFHCAL  = true;
@@ -719,8 +722,6 @@ int Fun4All_G4_FullDetectorModular(
   bool doFullEventTree = true;
   if(doFullEventTree){
     EventEvaluatorEIC *eval = new EventEvaluatorEIC("EVENTEVALUATOR",  outputroot + "_eventtree.root");
-    eval->set_reco_tracing_energy_threshold(0.05);
-    eval->set_reco_tracing_energy_threshold_BECAL(0.005);
     eval->Verbosity(0);
     if(specialSetting.Contains("GEOMETRYTREE"))
       eval->set_do_GEOMETRY(true);
@@ -916,7 +917,7 @@ void ParseTString(TString &specialSetting)
   if (specialSetting.Contains("XDEPTH")) // common for FHCAL and FEMC
   {
     G4FHCAL::SETTING::extradepth  = Enable::FHCAL && true;
-    G4FHCAL::SETTING::longer      = Enable::LFHCAL && true;
+    G4LFHCAL::SETTING::longer     = Enable::LFHCAL && true;
   }
   if (specialSetting.Contains("wDR")) // common for FHCAL and FEMC
   {

--- a/detectors/Modular/G4Setup_ModularDetector.C
+++ b/detectors/Modular/G4Setup_ModularDetector.C
@@ -32,8 +32,8 @@
 
 #include <G4_BlackHole.C>
 #include <G4_Magnet.C>
-#include <G4_Pipe_EIC.C>
 #include <G4_hFarFwdBeamLine_EIC.C>
+#include <G4_Pipe_EIC_simple.C>
 #include <G4_PlugDoor_EIC.C>
 #include <G4_User.C>
 #include <G4_World.C>

--- a/detectors/Modular/vis.mac
+++ b/detectors/Modular/vis.mac
@@ -28,7 +28,7 @@
 #/vis/open OGLIX
 /vis/open OGL 1200x900-0+0
 # increase display limit for more complex detectors
-/vis/ogl/set/displayListLimit 500000
+/vis/ogl/set/displayListLimit 5000000
 /vis/viewer/set/viewpointThetaPhi 260 -40
 /vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
 /vis/viewer/addCutawayPlane 0 0 0 m 0 -1 0


### PR DESCRIPTION
- adapted modular detector macro to be able to run standalone for all calo's with different particles
- changes calibration constants for LFHCAL & FEMC such that electrons would have their mean at 1
- added new beam chamber & corresponding beam pipe macro
- linked to https://github.com/eic/fun4all_eicdetectors/pull/30, https://github.com/eic/fun4all_eiccalibrations/pull/21