### PR TITLE
changes for LYSO barrel layer and TTL forward tracking clusters

### DIFF
--- a/common/G4_TTL_EIC.C
+++ b/common/G4_TTL_EIC.C
@@ -197,8 +197,7 @@ int make_forward_station(string name, PHG4Reco *g4Reco,
   ttl->set_double_param("rMax", rMax * cm);                    //
   ttl->set_double_param("offset_x", xoffset * cm);                    //
   ttl->set_double_param("tSilicon", tSilicon);                    //
-//   ttl->OverlapCheck(true);
-  ttl->OverlapCheck(false);
+  ttl->OverlapCheck(Enable::OVERLAPCHECK);
   
   g4Reco->registerSubsystem(ttl);
   return 0;
@@ -244,7 +243,7 @@ int make_forward_station_basic(string name, PHG4Reco *g4Reco,
   ttl->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::ConeEdge());
   ttl->get_geometry().set_N_Sector(1);
   ttl->get_geometry().set_material("G4_AIR");
-  ttl->OverlapCheck(true);
+  ttl->OverlapCheck(Enable::OVERLAPCHECK);
   
   const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
   const double mm = .1 * cm;
@@ -280,7 +279,7 @@ int make_barrel_layer(string name, PHG4Reco *g4Reco,
   ttl->set_double_param("rMin", radius * cm);                    //
   ttl->set_double_param("length", 2.0 * halflength * cm);
   ttl->set_double_param("tSilicon", tSilicon);                    //
-  ttl->OverlapCheck(false);
+  ttl->OverlapCheck(Enable::OVERLAPCHECK);
 
   g4Reco->registerSubsystem(ttl);
   return 0;
@@ -324,7 +323,7 @@ int make_barrel_layer_basic(string name, PHG4Reco *g4Reco,
     cyl->set_double_param("place_z", zOffset);
 
     if (l == 0) cyl->SetActive();  //only the Silicon Sensor is active
-    cyl->OverlapCheck(true);
+    cyl->OverlapCheck(Enable::OVERLAPCHECK);
     g4Reco->registerSubsystem(cyl);
     currRadius = currRadius+thickness[l];
 //     cout << currRadius << endl;
@@ -365,7 +364,7 @@ int make_barrel_layer_LYSO_basic(string name, PHG4Reco *g4Reco,
     cyl->set_double_param("place_z", zOffset);
 
     if (l == 2) cyl->SetActive();  //only the Silicon Sensor is active
-    cyl->OverlapCheck(true);
+    cyl->OverlapCheck(Enable::OVERLAPCHECK);
     g4Reco->registerSubsystem(cyl);
     currRadius = currRadius+thickness[l];
 //     cout << currRadius << endl;

--- a/common/G4_Tracking_Modular.C
+++ b/common/G4_Tracking_Modular.C
@@ -256,12 +256,16 @@ void Tracking_Reco(TString specialSetting = "")
   
   // central barrel 
   if (Enable::CTTL){
+    float resLGAD_barrel = resLGAD;
+    if(G4TTL::SETTING::optionLYSO){
+      resLGAD_barrel = 35e-1; // https://cds.cern.ch/record/2667167/files/CMS-TDR-020.pdf page 33 bottom
+    }
     for (int i = 0; i < G4TTL::layer[1]; i++){
       kalman->add_phg4hits(Form("G4HIT_CTTL_%d", i),           //      const std::string& phg4hitsNames,
                           PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
                           999,                               //      const float radres,
-                          resLGAD,                    //      const float phires,
-                          resLGAD,                    //      const float lonres, *ignored in plane detector*
+                          resLGAD_barrel,                //      const float phires,
+                          resLGAD_barrel,                //      const float lonres, *ignored in plane detector*
                           0.95,                              //      const float eff,
                           0);                                //      const float noise
       kalman -> add_cylinder_state(Form("CTTL_%d",i), G4TTL::positionToVtx[1][i]);

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -580,6 +580,10 @@ int Fun4All_G4_FullDetectorModular(
   Enable::BECAL_CLUSTER = Enable::BECAL_TOWER && true;
   Enable::BECAL_EVAL    = Enable::BECAL_CLUSTER && false;
   
+
+  Enable::FTTL_CLUSTER = Enable::FTTL && true;
+  Enable::ETTL_CLUSTER = Enable::ETTL && true;
+
   // Other options
   Enable::GLOBAL_RECO = true;
   Enable::GLOBAL_FASTSIM = true;
@@ -694,6 +698,9 @@ int Fun4All_G4_FullDetectorModular(
 
   if (Enable::BECAL_TOWER) BECAL_Towers();
   if (Enable::BECAL_CLUSTER) BECAL_Clusters();
+
+  if (Enable::FTTL_CLUSTER) FTTL_Clustering();
+  if (Enable::ETTL_CLUSTER) ETTL_Clustering();
   
   if (Enable::DSTOUT_COMPRESS) ShowerCompress();
 
@@ -1036,6 +1043,10 @@ void ParseTString(TString &specialSetting)
   else if (specialSetting.Contains("TTLF"))
     G4TTL::SETTING::optionGeo    = 4;
 
+  if (specialSetting.Contains("LYSO")){
+    G4TTL::SETTING::optionLYSO    = true;
+    G4TTL::SETTING::optionBasicGeo    = true;
+  }
   if (specialSetting.Contains("TTLBasicGeo")){
     G4TTL::SETTING::optionBasicGeo    = true;
   } else {


### PR DESCRIPTION
This PR requires https://github.com/eic/fun4all_eicdetectors/pull/48 to be merged!

The PR adds an alternative timing/tracking layer for the barrel based on LYSO crystals. For now, this implementation is basic and just accounts for the right material budget and expected resolutions.

In addition, the option to clusterize forward/backward TTL layer hits into useable tracking clusters is added.