### PR TITLE
Fix femc

### DIFF
--- a/common/G4_FEMC_EIC.C
+++ b/common/G4_FEMC_EIC.C
@@ -3,6 +3,8 @@
 
 #include <GlobalVariables.C>
 
+#include <G4_hFarFwdBeamLine_EIC.C>
+
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>
 

--- a/common/G4_FEMC_EIC.C
+++ b/common/G4_FEMC_EIC.C
@@ -76,7 +76,7 @@ void FEMCInit()
 
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FEMC::outer_radius);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FEMC::Gz0 + G4FEMC::Gdz / 2.);
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -10*cm);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -10 * cm);
 }
 
 void FEMCSetup(PHG4Reco *g4Reco)
@@ -109,25 +109,40 @@ void FEMCSetup(PHG4Reco *g4Reco)
   // asymmetric ECAL around beampipe
   else if (G4FEMC::SETTING::asymmetric)
   {
-    if (Enable::IP6){
+    if (Enable::IP6)
+    {
       if (G4FEMC::SETTING::readoutsplit)
+      {
         mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_IP6-asymmetric_ROS.txt";
+      }
       else
+      {
         mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_IP6-asymmetric.txt";
-    } else {
+      }
+    }
+    else
+    {
       if (G4FEMC::SETTING::readoutsplit)
+      {
         mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_asymmetric_ROS.txt";
+      }
       else
+      {
         mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_asymmetric.txt";
+      }
     }
   }
   // ECAL surrounding dual readout calorimeter
   else if (G4FEMC::SETTING::FwdSquare)
   {
     if (G4FEMC::SETTING::readoutsplit)
+    {
       mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_FwdSquare_ROS.txt";
+    }
     else
+    {
       mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_FwdSquare.txt";
+    }
   }
   // ECAL surrounding dual readout calorimeter
   else if (G4FEMC::SETTING::wDR)
@@ -195,25 +210,40 @@ void FEMC_Towers()
   // asymmetric ECAL around beampipe
   else if (G4FEMC::SETTING::asymmetric)
   {
-    if (Enable::IP6){
+    if (Enable::IP6)
+    {
       if (G4FEMC::SETTING::readoutsplit)
+      {
         mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_IP6-asymmetric_ROS.txt";
+      }
       else
+      {
         mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_IP6-asymmetric.txt";
-    } else {
+      }
+    }
+    else
+    {
       if (G4FEMC::SETTING::readoutsplit)
+      {
         mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_asymmetric_ROS.txt";
+      }
       else
+      {
         mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_asymmetric.txt";
+      }
     }
   }
   // ECAL surrounding dual readout calorimeter
   else if (G4FEMC::SETTING::FwdSquare)
   {
     if (G4FEMC::SETTING::readoutsplit)
+    {
       mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_FwdSquare_ROS.txt";
+    }
     else
+    {
       mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_FwdSquare.txt";
+    }
   }
   // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
   else
@@ -290,9 +320,13 @@ void FEMC_Towers()
   TowerCalibration2->Verbosity(verbosity);
   TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
   if (G4FEMC::SETTING::readoutsplit)
-    TowerCalibration2->set_calib_const_GeV_ADC(1.0 / (0.249*0.84));  // sampling fraction = 0.249 for e-
-  else 
+  {
+    TowerCalibration2->set_calib_const_GeV_ADC(1.0 / (0.249 * 0.84));  // sampling fraction = 0.249 for e-
+  }
+  else
+  {
     TowerCalibration2->set_calib_const_GeV_ADC(1.0 / 0.249);  // sampling fraction = 0.249 for e-
+  }
   TowerCalibration2->set_pedstal_ADC(0);
   se->registerSubsystem(TowerCalibration2);
 

--- a/detectors/EICDetector/G4Setup_EICDetector.C
+++ b/detectors/EICDetector/G4Setup_EICDetector.C
@@ -10,7 +10,7 @@
 #include <G4_CEmc_EIC.C>
 #include <G4_DIRC.C>
 #include <G4_EEMC.C>
-#include <G4_FEMC.C>
+#include <G4_FEMC_EIC.C>
 #include <G4_FHCAL.C>
 #include <G4_FST_EIC.C>
 #include <G4_GEM_EIC.C>


### PR DESCRIPTION
The Fun4AllG4_EICDetector.C crashed with competing Enable::FEMC variables (from G4_FEMC.C and G4_FEMC_EIC.C) This PR puts the G4_FEMC_EIC.C back into the eic detector. G4_FEMC_EIC.C needs to include G4_hFarFwdBeamLine_EIC.C to resolve Enable::IP6