### PR TITLE
switch to 3d field as default

### DIFF
--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -369,9 +369,9 @@ int Fun4All_G4_EICDetector(
   // Magnet Settings
   //---------------
 
-  //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
-  //  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // default map from the calibration database
-  G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
+  //  const string magfield = "1.4"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+  //  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz.root");  // default map from the calibration database
+  G4MAGNET::magfield_rescale = 1.;  // in case you want to play with field
 
   //---------------
   // Pythia Decayer

--- a/detectors/EICDetector/G4Setup_EICDetector.C
+++ b/detectors/EICDetector/G4Setup_EICDetector.C
@@ -133,7 +133,7 @@ int G4Setup()
   if (stringline.fail())
   {  // conversion to double fails -> we have a string
 
-    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos)
+    if (G4MAGNET::magfield.find("sphenix3dbigmapxyz") != string::npos)
     {
       g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
     }


### PR DESCRIPTION
The G4_Magnet.C macro now defaults to the 3d map. It can be overridden in the Fun4All macro but the previous settings just used the 3d map with 2d reading (leaving us with no field I assume).
This PR now makes this consistent, if using the 2d map one needs to change the setting in the FUn4All macro to

G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // 2d map
G4MAGNET::magfield_rescale = -1.4 / 1.5;  // in case you want to play with field
