### PR TITLE
Fix more 3dfield

### DIFF
--- a/common/G4_FEMC.C
+++ b/common/G4_FEMC.C
@@ -59,7 +59,7 @@ void FEMCInit()
 {
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FEMC::outer_radius);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FEMC::Gz0 + G4FEMC::Gdz / 2.);
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -10*cm);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -10.);
 }
 
 void FEMCSetup(PHG4Reco *g4Reco, const int absorberactive = 0)

--- a/common/G4_FHCAL.C
+++ b/common/G4_FHCAL.C
@@ -89,7 +89,7 @@ void FHCALInit()
 
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FHCAL::outer_radius);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FHCAL::Gz0 + G4FHCAL::Gdz / 2.);
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -10*cm);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -10.);
 }
 
 void FHCALSetup(PHG4Reco *g4Reco)

--- a/detectors/AllSilicon/Fun4All_G4_LBLDetector.C
+++ b/detectors/AllSilicon/Fun4All_G4_LBLDetector.C
@@ -287,9 +287,14 @@ int Fun4All_G4_LBLDetector(
   // Magnet Settings
   //---------------
 
-  //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+  //  const string magfield = "1.4"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+// This is the 3d fieldmap setting (default)
+//  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz.root");  // default map from the calibration database
+//  G4MAGNET::magfield_rescale = 1.;  // in case you want to play with field
+
+// for 2d map use these settings
   //  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // default map from the calibration database
-  G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
+//  G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
 
   //---------------
   // Pythia Decayer

--- a/detectors/AllSilicon/G4Setup_LBLDetector.C
+++ b/detectors/AllSilicon/G4Setup_LBLDetector.C
@@ -89,7 +89,7 @@ int G4Setup()
   if (stringline.fail())
   {  // conversion to double fails -> we have a string
 
-    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos)
+    if (G4MAGNET::magfield.find("sphenix3dbigmapxyz") != string::npos)
     {
       g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
     }

--- a/detectors/Modular/Fun4All_G4_FullDetectorModular.C
+++ b/detectors/Modular/Fun4All_G4_FullDetectorModular.C
@@ -624,7 +624,14 @@ int Fun4All_G4_FullDetectorModular(
     G4MAGNET::magfield = magfield;
     //  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // default map from the calibration database
   } else {
-    G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
+    if (G4MAGNET::magfield.find("sphenix3dbigmapxyz") != string::npos)
+    {
+      G4MAGNET::magfield_rescale = 1.;  // 3d fieldmap uses 1.4T
+    }
+    else
+    {
+      G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
+    }
   }
   //---------------
   // Pythia Decayer

--- a/detectors/Modular/G4Setup_ModularDetector.C
+++ b/detectors/Modular/G4Setup_ModularDetector.C
@@ -160,7 +160,7 @@ int G4Setup(TString specialSetting = ""){
   istringstream stringline(G4MAGNET::magfield);
   stringline >> fieldstrength;
   if (stringline.fail()){  // conversion to double fails -> we have a string
-    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos){
+    if (G4MAGNET::magfield.find("sphenix3dbigmapxyz") != string::npos){
       g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
     } else {
       g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::kField2D);

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -337,9 +337,14 @@ int Fun4All_G4_fsPHENIX(
   // Magnet Settings
   //---------------
 
-  //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+  //  const string magfield = "1.4"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+// This is the 3d fieldmap setting (default)
+//  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz.root");  // default map from the calibration database
+//  G4MAGNET::magfield_rescale = 1.;  // in case you want to play with field
+
+// for 2d map use these settings
   //  G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // default map from the calibration database
-  G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
+//  G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T
 
   //---------------
   // Pythia Decayer

--- a/detectors/fsPHENIX/G4Setup_fsPHENIX.C
+++ b/detectors/fsPHENIX/G4Setup_fsPHENIX.C
@@ -84,7 +84,7 @@ int G4Setup()
   if (stringline.fail())
   {  // conversion to double fails -> we have a string
 
-    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos)
+    if (G4MAGNET::magfield.find("sphenix3dbigmapxyz") != string::npos)
     {
       g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
     }


### PR DESCRIPTION
This PR updates all Fun4All macros which were still using a botched mixture of 2d and 3d fields. Now 3d is the default, falling back to 2d needs these 2 lines in the Fun4All macro:
G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");  // default map from the calibration database
G4MAGNET::magfield_rescale = -1.4 / 1.5;  // make consistent with expected Babar field strength of 1.4T

